### PR TITLE
Fix format alias count (17 → 14) in package-formats docs

### DIFF
--- a/src/content/docs/docs/package-formats.mdx
+++ b/src/content/docs/docs/package-formats.mdx
@@ -13,7 +13,7 @@ This page is a quick reference index. Click through to the detailed guide pages 
 
 ## Complete Format Reference
 
-**36 native formats** with full wire-protocol support, plus **17 aliases** for alternative clients that share an underlying protocol. Custom formats can be added at any time via [WASM plugins](/docs/advanced/plugins/).
+**36 native formats** with full wire-protocol support, plus **14 aliases** for alternative clients that share an underlying protocol. Custom formats can be added at any time via [WASM plugins](/docs/advanced/plugins/).
 
 | # | Format | Key | Category | Native Clients |
 |---|--------|-----|----------|----------------|
@@ -178,10 +178,8 @@ Many package managers share underlying protocols. These aliases automatically re
 | `pnpm` | npm | `oras` | docker |
 | `gradle` | maven | `wasm_oci` | docker |
 | `poetry` | pypi | `helm_oci` | docker |
-| `conda` | pypi | `cursor` | vscode |
-| `chocolatey` | nuget | `windsurf` | vscode |
-| `powershell` | nuget | `kiro` | vscode |
-| `opentofu` | terraform | | |
+| `conda` | pypi | `chocolatey` | nuget |
+| `powershell` | nuget | `opentofu` | terraform |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixed alias count from 17 to 14 to match the backend `RepositoryFormat` enum
- Removed `cursor`, `windsurf`, `kiro` from the alias table — these are routing-level aliases in `formats/mod.rs` but not in the enum, so they can't be used as `format` values via the API
- The VS Code entry's "Native Clients" column already correctly lists these editors as compatible clients

Found during full documentation sync audit against backend source of truth.