### PR TITLE
docs: add Monitoring & Observability section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -83,6 +83,14 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Monitoring & Observability',
+          items: [
+            { label: 'Health Checks', slug: 'docs/monitoring/health-checks' },
+            { label: 'Distributed Tracing', slug: 'docs/monitoring/tracing' },
+            { label: 'Prometheus Metrics', slug: 'docs/monitoring/metrics' },
+          ],
+        },
+        {
           label: 'Deployment',
           items: [
             { label: 'Helm Chart', slug: 'docs/deployment/helm' },

--- a/src/content/docs/docs/deployment/kubernetes.mdx
+++ b/src/content/docs/docs/deployment/kubernetes.mdx
@@ -341,18 +341,26 @@ spec:
             limits:
               memory: "4Gi"
               cpu: "2000m"
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /api/v1/health
+              path: /livez
               port: 8080
-            initialDelaySeconds: 60
-            periodSeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /api/v1/health
+              path: /readyz
               port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
       volumes:
         - name: artifact-storage
           persistentVolumeClaim:

--- a/src/content/docs/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/docs/getting-started/quickstart.mdx
@@ -84,7 +84,13 @@ Always enable 2FA on the admin account. This protects against credential theft a
 5. **Verify everything works**:
 
 ```bash
-# Health check
+# Quick liveness check
+curl http://localhost:30080/livez
+
+# Readiness check (DB + migrations + setup)
+curl http://localhost:30080/readyz
+
+# Full health dashboard
 curl http://localhost:30080/health
 
 # List repositories

--- a/src/content/docs/docs/monitoring/health-checks.mdx
+++ b/src/content/docs/docs/monitoring/health-checks.mdx
@@ -1,0 +1,333 @@
+---
+title: "Health Checks"
+description: "Health check endpoints for Kubernetes probes, Docker healthchecks, and monitoring dashboards"
+---
+
+Artifact Keeper exposes multiple health check endpoints, each designed for a specific use case. Lightweight probes keep Kubernetes from restarting pods unnecessarily, while the full health dashboard gives operators visibility into every dependent service.
+
+## Endpoints Reference
+
+| Endpoint | Purpose | Checks performed | Recommended use |
+|----------|---------|------------------|-----------------|
+| `/livez` | Liveness probe | None (if Axum routes the request, the process is alive) | Kubernetes `livenessProbe` |
+| `/readyz` | Readiness probe | Database connectivity, migrations, setup completion | Kubernetes `readinessProbe` and `startupProbe` |
+| `/health` | Full health dashboard | Database, Trivy, Meilisearch, OpenSCAP, Dependency-Track, storage backend, DB pool stats | Monitoring dashboards, alerting |
+| `/healthz` | Alias for `/health` | Same as `/health` | Monitoring dashboards |
+| `/ready` | Legacy alias for `/readyz` | Same as `/readyz` | Backward compatibility |
+
+## Endpoint Details
+
+### `/livez` -- Liveness Probe
+
+A zero-dependency check. If the Axum HTTP server can route the request, the process is alive. No database queries, no external service checks.
+
+Returns `200 OK` with:
+
+```json
+{"status":"ok"}
+```
+
+This endpoint always succeeds as long as the process is running. Use it as the Kubernetes liveness probe because it never triggers unnecessary restarts due to external service failures.
+
+### `/readyz` -- Readiness Probe
+
+Verifies that the server is ready to accept traffic by checking three things:
+
+1. **Database connectivity** -- executes `SELECT 1` against PostgreSQL
+2. **Migrations** -- queries the `_sqlx_migrations` table to confirm all migrations have been applied
+3. **Setup completion** -- confirms the admin password has been set (first-time setup is complete)
+
+Returns `200 OK` when all checks pass, or `503 Service Unavailable` when any check fails.
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "database": {
+      "status": "healthy",
+      "message": null
+    },
+    "migrations": {
+      "status": "healthy",
+      "message": null
+    },
+    "setup_complete": {
+      "status": "healthy",
+      "message": null
+    }
+  }
+}
+```
+
+### `/health` -- Full Health Dashboard
+
+Performs a comprehensive check of every dependent service and includes database connection pool statistics. Checks:
+
+- **Database** -- connection and query execution
+- **Trivy** -- vulnerability scanner reachability
+- **Meilisearch** -- search engine reachability
+- **OpenSCAP** -- compliance scanner reachability
+- **Dependency-Track** -- SBOM analysis platform reachability
+- **Storage backend** -- active read/write probe (see [Storage Health Check Details](#storage-health-check-details))
+- **DB pool** -- connection pool utilization statistics
+
+Returns `200 OK` when all services are healthy, or `503 Service Unavailable` when any service is degraded.
+
+:::caution
+Do not use `/health` as a Kubernetes liveness probe. If an external service like Trivy or Meilisearch goes down, the `/health` endpoint returns 503, which would cause Kubernetes to restart your backend pods -- even though the backend itself is functioning correctly. This creates cascading failures. Use `/livez` for liveness instead.
+:::
+
+## Response Examples
+
+### Liveness probe
+
+```bash
+curl -s http://localhost:8080/livez | jq .
+```
+
+```json
+{
+  "status": "ok"
+}
+```
+
+### Readiness probe
+
+```bash
+curl -s http://localhost:8080/readyz | jq .
+```
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "database": {
+      "status": "healthy",
+      "message": null
+    },
+    "migrations": {
+      "status": "healthy",
+      "message": null
+    },
+    "setup_complete": {
+      "status": "healthy",
+      "message": null
+    }
+  }
+}
+```
+
+### Full health dashboard
+
+```bash
+curl -s http://localhost:8080/health | jq .
+```
+
+```json
+{
+  "status": "healthy",
+  "checks": {
+    "database": {
+      "status": "healthy",
+      "message": null
+    },
+    "trivy": {
+      "status": "healthy",
+      "message": null
+    },
+    "meilisearch": {
+      "status": "healthy",
+      "message": null
+    },
+    "openscap": {
+      "status": "healthy",
+      "message": null
+    },
+    "dependency_track": {
+      "status": "healthy",
+      "message": null
+    },
+    "storage": {
+      "status": "healthy",
+      "message": null
+    }
+  },
+  "db_pool": {
+    "active": 2,
+    "idle": 18,
+    "max": 20,
+    "size": 20
+  }
+}
+```
+
+## Kubernetes Configuration
+
+The recommended probe configuration uses each endpoint for the purpose it was designed for:
+
+```yaml
+containers:
+  - name: backend
+    image: ghcr.io/artifact-keeper/artifact-keeper-backend:latest
+    ports:
+      - containerPort: 8080
+    startupProbe:
+      httpGet:
+        path: /readyz
+        port: 8080
+      periodSeconds: 5
+      failureThreshold: 30        # 150s max startup for slow migrations
+    livenessProbe:
+      httpGet:
+        path: /livez
+        port: 8080
+      periodSeconds: 15
+      timeoutSeconds: 3
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /readyz
+        port: 8080
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 3
+```
+
+### Why each endpoint is chosen
+
+**`startupProbe` uses `/readyz`** -- During startup, the server needs time to connect to PostgreSQL and run migrations. The startup probe gives it up to 150 seconds (5s period x 30 failures) before Kubernetes considers the container failed. Once the startup probe succeeds, the liveness and readiness probes take over.
+
+**`livenessProbe` uses `/livez`** -- The liveness probe answers one question: is the process still running and able to handle HTTP requests? By using `/livez`, which has zero external dependencies, you avoid cascading restarts when a downstream service (database, Trivy, Meilisearch) is temporarily unavailable. Kubernetes only restarts the pod if the backend process itself is hung or crashed.
+
+**`readinessProbe` uses `/readyz`** -- The readiness probe controls whether the pod receives traffic. If the database becomes unreachable or migrations are pending after a rolling update, `/readyz` returns 503 and Kubernetes removes the pod from the Service endpoints. Traffic shifts to healthy pods without restarting anything.
+
+:::tip
+The startup probe prevents the liveness probe from running during initial boot. Without it, a slow migration could cause Kubernetes to kill the pod before it finishes starting. Always configure a startup probe for Artifact Keeper deployments.
+:::
+
+## Docker Compose Healthcheck
+
+For Docker Compose deployments, use `/readyz` to gate dependent services:
+
+```yaml
+services:
+  backend:
+    image: ghcr.io/artifact-keeper/artifact-keeper-backend:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/readyz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+```
+
+Other services can then use `depends_on` with a health condition:
+
+```yaml
+services:
+  frontend:
+    image: ghcr.io/artifact-keeper/artifact-keeper-web:latest
+    depends_on:
+      backend:
+        condition: service_healthy
+```
+
+## Storage Health Check Details
+
+The `/health` endpoint performs an active probe of the configured storage backend, not just a connectivity check.
+
+### Filesystem storage
+
+When `STORAGE_BACKEND=filesystem`, the health check:
+
+1. **Writes** a `.health-probe` file to the configured `STORAGE_PATH`
+2. **Reads** the file back and verifies its contents
+3. **Deletes** the file
+
+This validates that the storage path exists, the process has read/write/delete permissions, and the filesystem is responsive. If any step fails, the storage check reports `unhealthy` with a descriptive error message.
+
+### S3 storage
+
+When `STORAGE_BACKEND=s3`, the health check validates that the required S3 configuration (bucket, region, credentials) is present and correctly specified.
+
+## DB Pool Statistics
+
+The `db_pool` field in the `/health` response provides real-time connection pool metrics from SQLx:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `active` | integer | Connections currently checked out and executing queries |
+| `idle` | integer | Connections sitting in the pool, available for immediate use |
+| `max` | integer | Configured maximum pool size (set via `DB_POOL_SIZE`, default `20`) |
+| `size` | integer | Total connections currently in the pool (`active + idle`) |
+
+These metrics are useful for capacity planning and diagnosing connection exhaustion:
+
+- **`active` approaching `max`** -- The application is under heavy database load. Consider increasing `DB_POOL_SIZE` or optimizing slow queries.
+- **`size` less than `max`** -- The pool has not yet needed to open all allowed connections. This is normal under light load.
+- **`idle` at zero, `active` at `max`** -- All connections are in use. New requests will block waiting for a connection. This typically indicates the pool is undersized for the workload or a query is holding connections too long.
+
+## Troubleshooting
+
+### `/readyz` returning 503 during startup
+
+This is expected behavior. The readiness probe returns 503 until:
+
+1. PostgreSQL is reachable
+2. All database migrations have completed
+3. The admin password has been set (first-time setup is finished)
+
+If using Kubernetes, the startup probe handles this gracefully. For Docker Compose, the `start_period` setting in the healthcheck gives the backend time to initialize before Docker considers it unhealthy.
+
+If `/readyz` continues to return 503 after startup:
+
+```bash
+# Check the response body for which check is failing
+curl -s http://localhost:8080/readyz | jq .
+```
+
+- **`database: unhealthy`** -- Verify `DATABASE_URL` is correct and PostgreSQL is reachable
+- **`migrations: unhealthy`** -- Check backend logs for migration errors
+- **`setup_complete: unhealthy`** -- Complete the first-time setup by setting the admin password, or set the `ADMIN_PASSWORD` environment variable
+
+### `/health` showing unhealthy storage
+
+The storage health check performs real I/O operations. Common causes of failure:
+
+- **Permission denied** -- The backend process does not have read/write access to `STORAGE_PATH`. Verify ownership and permissions:
+  ```bash
+  ls -la /var/lib/artifact-keeper/artifacts
+  ```
+- **Path does not exist** -- The `STORAGE_PATH` directory has not been created. Create it and set appropriate permissions:
+  ```bash
+  mkdir -p /var/lib/artifact-keeper/artifacts
+  chown -R artifact-keeper:artifact-keeper /var/lib/artifact-keeper/artifacts
+  ```
+- **Disk full** -- The health probe write will fail if the filesystem has no free space. Check disk usage:
+  ```bash
+  df -h /var/lib/artifact-keeper/artifacts
+  ```
+- **S3 misconfiguration** -- When using S3 storage, verify that `S3_BUCKET`, `S3_REGION`, and credentials are set correctly.
+
+### `/health` showing unhealthy external services
+
+External service checks (Trivy, Meilisearch, OpenSCAP, Dependency-Track) report unhealthy when the service is unreachable or not responding.
+
+:::tip
+External service failures do not affect `/livez` or `/readyz`. The backend continues to serve artifacts and API requests normally -- only features that depend on the specific service (vulnerability scanning, full-text search, compliance checks) are degraded.
+:::
+
+To diagnose:
+
+- **Trivy unhealthy** -- Verify `TRIVY_URL` is correct and the Trivy server is running:
+  ```bash
+  curl -s http://localhost:8090/healthz
+  ```
+- **Meilisearch unhealthy** -- Verify `MEILISEARCH_URL` and check if the Meilisearch process is running:
+  ```bash
+  curl -s http://localhost:7700/health
+  ```
+- **OpenSCAP unhealthy** -- Verify the OpenSCAP service is running on port 8091
+- **Dependency-Track unhealthy** -- Verify Dependency-Track is running on port 8092
+
+If you do not use a particular service, it is safe to ignore its unhealthy status in the `/health` response. The service will show as unhealthy if its URL is not configured or the service is not deployed.

--- a/src/content/docs/docs/monitoring/metrics.mdx
+++ b/src/content/docs/docs/monitoring/metrics.mdx
@@ -1,0 +1,235 @@
+---
+title: "Prometheus Metrics"
+description: "Monitor Artifact Keeper with Prometheus metrics covering HTTP performance, artifact operations, security scanning, backups, and infrastructure health"
+---
+
+Artifact Keeper exposes Prometheus-compatible metrics at `/api/v1/admin/metrics`. These metrics cover HTTP request performance, artifact operations, security scanning, backup operations, and infrastructure health, giving you full observability into your registry.
+
+## Accessing Metrics
+
+Scrape the metrics endpoint directly:
+
+```bash
+curl http://localhost:8080/api/v1/admin/metrics
+```
+
+:::caution
+The metrics endpoint requires admin authentication in production. Include your API key or bearer token:
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+  https://registry.example.com/api/v1/admin/metrics
+```
+:::
+
+The response is in standard Prometheus exposition format, ready for ingestion by any Prometheus-compatible scraper.
+
+## HTTP Request Metrics
+
+These metrics track all inbound HTTP traffic to the backend API.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ak_http_requests_total` | Counter | `method`, `path` | Total HTTP requests received |
+| `ak_http_responses_total` | Counter | `method`, `path`, `status` | Total HTTP responses sent |
+| `ak_http_request_duration_seconds` | Histogram | `method`, `path`, `status` | Request latency distribution |
+| `ak_http_requests_in_flight` | Gauge | `method`, `path` | Number of currently active requests |
+
+:::tip
+Paths are normalized to prevent high-cardinality label explosion. UUIDs are replaced with `:id` and numeric identifiers are replaced with `:id`. For example, `/api/v1/repositories/550e8400-e29b-41d4-a716-446655440000/artifacts` becomes `/api/v1/repositories/:id/artifacts`.
+:::
+
+### Example Queries
+
+Request rate over the last 5 minutes:
+
+```promql
+rate(ak_http_requests_total[5m])
+```
+
+95th percentile latency by path:
+
+```promql
+histogram_quantile(0.95, rate(ak_http_request_duration_seconds_bucket[5m]))
+```
+
+## Artifact Metrics
+
+Track upload and download activity across repositories and package formats.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ak_artifact_uploads_total` | Counter | `repository`, `format` | Total artifact uploads |
+| `ak_artifact_upload_size_bytes` | Histogram | `format` | Upload size distribution |
+| `ak_artifact_downloads_total` | Counter | `repository`, `format` | Total artifact downloads |
+
+### Example Queries
+
+Upload rate by format over the last hour:
+
+```promql
+sum(rate(ak_artifact_uploads_total[1h])) by (format)
+```
+
+Average upload size by format:
+
+```promql
+rate(ak_artifact_upload_size_bytes_sum[5m]) / rate(ak_artifact_upload_size_bytes_count[5m])
+```
+
+## Infrastructure Gauges
+
+These gauges are updated every 5 minutes from the database and provide a high-level view of registry state.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ak_storage_used_bytes` | Gauge | - | Total storage consumed by artifacts |
+| `ak_artifacts_total` | Gauge | - | Total number of stored artifacts |
+| `ak_repositories_total` | Gauge | - | Total number of repositories |
+| `ak_users_total` | Gauge | - | Total number of registered users |
+
+These metrics are useful for capacity planning dashboards and tracking growth trends over time.
+
+## Database Connection Pool
+
+The database connection pool metrics are critical for detecting connection exhaustion and ensuring query throughput.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ak_db_pool_connections_active` | Gauge | - | Connections currently in use |
+| `ak_db_pool_connections_idle` | Gauge | - | Idle connections available in pool |
+| `ak_db_pool_connections_max` | Gauge | - | Configured maximum connections |
+| `ak_db_pool_connections_size` | Gauge | - | Total connections in pool (active + idle) |
+
+:::caution
+When `ak_db_pool_connections_active` approaches `ak_db_pool_connections_max`, new database queries will start queuing. Sustained saturation leads to request timeouts and degraded performance. Monitor the ratio closely and scale your pool size or database resources before reaching capacity.
+:::
+
+### Example Queries
+
+Pool utilization percentage:
+
+```promql
+ak_db_pool_connections_active / ak_db_pool_connections_max * 100
+```
+
+## Operations Metrics
+
+Track background operations including backups, security scanning, webhooks, and lifecycle cleanup.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ak_backup_operations_total` | Counter | `type`, `status` | Backup operations by type and outcome (success/failure) |
+| `ak_backup_duration_seconds` | Histogram | `type` | Backup duration distribution |
+| `ak_security_scans_total` | Counter | `scanner`, `status` | Security scan operations by scanner and outcome |
+| `ak_security_scan_duration_seconds` | Histogram | `scanner` | Scan duration distribution |
+| `ak_webhook_deliveries_total` | Counter | `event`, `status` | Webhook delivery attempts by event type and outcome |
+| `ak_cleanup_items_removed_total` | Counter | `type` | Items removed by lifecycle cleanup policies |
+
+### Example Queries
+
+Backup failure rate:
+
+```promql
+rate(ak_backup_operations_total{status="failure"}[1h])
+```
+
+Average scan duration by scanner:
+
+```promql
+rate(ak_security_scan_duration_seconds_sum[5m]) / rate(ak_security_scan_duration_seconds_count[5m])
+```
+
+## Kubernetes ServiceMonitor
+
+If you run Prometheus Operator in your Kubernetes cluster, create a `ServiceMonitor` to automatically discover and scrape the metrics endpoint:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: artifact-keeper
+  namespace: artifact-keeper
+spec:
+  selector:
+    matchLabels:
+      app: backend
+  endpoints:
+    - port: http
+      path: /api/v1/admin/metrics
+      interval: 30s
+```
+
+:::tip
+If admin authentication is required, configure the `ServiceMonitor` with a bearer token from a Kubernetes Secret:
+
+```yaml
+endpoints:
+  - port: http
+    path: /api/v1/admin/metrics
+    interval: 30s
+    bearerTokenSecret:
+      name: artifact-keeper-secrets
+      key: metrics-token
+```
+:::
+
+## Grafana Dashboard
+
+Build a Grafana dashboard with the following recommended panels for a complete operational overview:
+
+- **Request rate and latency** -- Use `ak_http_request_duration_seconds` to show request throughput and p50/p95/p99 latency over time.
+- **Error rate by status code** -- Graph `rate(ak_http_responses_total{status=~"5.."}[5m])` to surface server-side failures.
+- **Upload and download rates by format** -- Break down `ak_artifact_uploads_total` and `ak_artifact_downloads_total` by the `format` label to see which package ecosystems are most active.
+- **Database pool utilization** -- Plot the ratio `ak_db_pool_connections_active / ak_db_pool_connections_max` as a gauge to visualize headroom.
+- **Storage growth over time** -- Track `ak_storage_used_bytes` to forecast when you will need to expand capacity.
+- **Backup and scan status** -- Show `ak_backup_operations_total` and `ak_security_scans_total` split by `status` to catch failures quickly.
+
+## Alerting Examples
+
+Below are example Prometheus alerting rules you can adapt for your environment. Save these as part of your Prometheus rule files or `PrometheusRule` custom resource:
+
+```yaml
+groups:
+  - name: artifact-keeper
+    rules:
+      - alert: HighErrorRate
+        expr: >
+          rate(ak_http_responses_total{status=~"5.."}[5m])
+          / rate(ak_http_responses_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Error rate above 5%"
+          description: "More than 5% of HTTP responses have been 5xx errors for the last 5 minutes."
+
+      - alert: DBPoolExhaustion
+        expr: ak_db_pool_connections_active / ak_db_pool_connections_max > 0.9
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "DB connection pool above 90% utilization"
+          description: "Active connections are near the pool maximum. Queries may begin queuing."
+
+      - alert: BackupFailure
+        expr: increase(ak_backup_operations_total{status="failure"}[1h]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Backup operation failed"
+          description: "At least one backup operation has failed in the last hour. Check logs for details."
+```
+
+:::tip
+Tune the `for` duration and threshold values to match your environment. A 5% error rate threshold is a reasonable starting point, but high-traffic registries may want a tighter threshold, while low-traffic instances may need a wider window to avoid false positives.
+:::
+
+## See Also
+
+- [Kubernetes Deployment](/docs/deployment/kubernetes) -- ServiceMonitor setup and production deployment
+- [Backup & Recovery](/docs/advanced/backup) -- Backup metrics and alerting
+- [Vulnerability Scanning](/docs/security/scanning) -- Security scan metrics and monitoring
+- [Configuration Reference](/docs/reference/environment) -- Environment variables for tuning metrics collection

--- a/src/content/docs/docs/monitoring/tracing.mdx
+++ b/src/content/docs/docs/monitoring/tracing.mdx
@@ -1,0 +1,166 @@
+---
+title: "Distributed Tracing"
+description: "Configure OpenTelemetry distributed tracing in Artifact Keeper for full request visibility across services"
+---
+
+Artifact Keeper supports opt-in OpenTelemetry distributed tracing. When enabled, spans are exported via OTLP gRPC to any compatible collector such as Jaeger, Grafana Tempo, Datadog, or AWS X-Ray. When disabled (the default), behavior is identical to stdout-only logging with zero overhead.
+
+## Configuration
+
+Tracing is controlled entirely through environment variables. No code changes or config files are required.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | _(unset)_ | OTLP collector endpoint (e.g., `http://jaeger:4317`). When unset, tracing exports are disabled. |
+| `OTEL_SERVICE_NAME` | No | `artifact-keeper` | Service name that appears in traces. |
+| `RUST_LOG` | No | `info,sqlx::query=info` | Log and trace filter directive. The default includes `sqlx::query=info` which enables database query spans. |
+
+:::tip
+Setting `OTEL_EXPORTER_OTLP_ENDPOINT` is the only variable required to activate tracing. Leave it unset to keep tracing fully disabled with no runtime cost.
+:::
+
+## Quick Start with Jaeger
+
+The fastest way to get tracing working locally is with Jaeger's all-in-one image.
+
+### 1. Add Jaeger to Docker Compose
+
+Add the following service to your `docker-compose.yml` (or a `docker-compose.override.yml`):
+
+```yaml
+jaeger:
+  image: jaegertracing/all-in-one:1.62
+  ports:
+    - "16686:16686"   # Jaeger UI
+    - "4317:4317"     # OTLP gRPC
+    - "4318:4318"     # OTLP HTTP
+```
+
+### 2. Configure the Backend
+
+Point the backend at the Jaeger OTLP endpoint:
+
+```yaml
+backend:
+  environment:
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+    OTEL_SERVICE_NAME: artifact-keeper
+```
+
+### 3. View Traces
+
+Start the stack, then open the Jaeger UI at [http://localhost:16686](http://localhost:16686). Select service **artifact-keeper** from the dropdown and click **Find Traces**.
+
+Each trace shows the full lifecycle of an HTTP request, including nested database queries, giving you a waterfall view of where time is spent.
+
+## What Gets Traced
+
+When tracing is enabled, Artifact Keeper emits the following span hierarchy:
+
+### HTTP Requests
+
+Every incoming HTTP request creates an `http_request` span containing:
+
+| Attribute | Description |
+|-----------|-------------|
+| `http.method` | HTTP method (`GET`, `POST`, `PUT`, `DELETE`, etc.) |
+| `http.route` | Matched route path (e.g., `/api/v1/artifacts/:id`) |
+| `http.status_code` | Response status code |
+| `correlation_id` | Unique request correlation ID |
+
+### Database Queries
+
+SQLx automatically emits a span for every SQL query executed during a request. These spans include the query text and execution time. Database query spans are enabled by the `sqlx::query=info` filter level in `RUST_LOG`.
+
+### Nested Span Tree
+
+Database query spans appear as children of the HTTP request span that triggered them. This gives you full request waterfall visibility -- you can see exactly which queries a handler executes and how long each one takes.
+
+```
+http_request GET /api/v1/artifacts/search?q=openssl  [45ms]
+  sqlx::query SELECT * FROM artifacts WHERE ...       [12ms]
+  sqlx::query SELECT * FROM scan_results WHERE ...     [8ms]
+  sqlx::query SELECT * FROM artifact_tags WHERE ...    [3ms]
+```
+
+## W3C Trace Context
+
+Artifact Keeper's correlation ID middleware supports the W3C `traceparent` header for distributed trace propagation across services.
+
+### Header Priority
+
+When determining the correlation ID for a request, the following priority order is used:
+
+| Priority | Source | Description |
+|----------|--------|-------------|
+| 1 (highest) | `X-Correlation-ID` header | Explicit correlation ID set by the caller |
+| 2 | `traceparent` header | Trace ID extracted from W3C Trace Context |
+| 3 (lowest) | Auto-generated | A new UUID is generated if no header is present |
+
+### Cross-Service Propagation
+
+If an upstream service (such as an API gateway or load balancer) sets a `traceparent` header, Artifact Keeper will extract the trace ID and use it as the correlation ID. This means the same trace ID appears in both the upstream service's spans and Artifact Keeper's spans, linking them together in your tracing backend.
+
+```bash
+# Example: calling Artifact Keeper with an existing trace context
+curl -H "traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" \
+  http://localhost:8080/api/v1/artifacts
+```
+
+:::tip
+If you are already using a service mesh or API gateway that propagates W3C Trace Context, Artifact Keeper will automatically participate in your existing distributed traces with no additional configuration.
+:::
+
+## Production Backends
+
+Artifact Keeper exports traces using the standard OTLP gRPC protocol, which is supported by all major observability platforms. Point `OTEL_EXPORTER_OTLP_ENDPOINT` at your collector.
+
+### Grafana Tempo
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317
+```
+
+### Datadog Agent
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4317
+```
+
+### AWS X-Ray (via ADOT Collector)
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://aws-otel-collector:4317
+```
+
+:::caution
+Ensure your collector is reachable from the Artifact Keeper backend container. If you are running in Kubernetes, the collector is typically deployed as a DaemonSet or sidecar. In Docker Compose, place the collector on the same Docker network as the backend.
+:::
+
+## Graceful Shutdown
+
+The OpenTelemetry tracer provider is wrapped in a guard (`OtelGuard`) that flushes all pending spans when the Artifact Keeper process shuts down. This ensures no trace data is lost during rolling deployments or container restarts.
+
+The flush happens automatically as part of the server's graceful shutdown sequence -- there is nothing to configure. If the process receives a `SIGTERM` (the standard signal used by Docker and Kubernetes), pending spans are exported to the collector before the process exits.
+
+## Local Development
+
+The local development Docker Compose file includes Jaeger pre-configured and ready to use. No additional setup is needed.
+
+```bash
+docker compose -f docker-compose.local-dev.yml up -d
+```
+
+Once the stack is running, the Jaeger UI is available at [http://localhost:16686](http://localhost:16686).
+
+The backend in the local dev compose is already configured with `OTEL_EXPORTER_OTLP_ENDPOINT` pointing at the local Jaeger instance. Make a few requests to the API or web UI, then open Jaeger and select the **artifact-keeper** service to see traces.
+
+:::tip
+To see database query detail in your traces, make sure `RUST_LOG` includes `sqlx::query=info` (this is the default). If you override `RUST_LOG`, add `sqlx::query=info` to your custom filter to preserve database span visibility.
+:::
+
+## See Also
+
+- [Configuration](/docs/getting-started/configuration) - Full environment variable reference
+- [Docker Compose Deployment](/docs/deployment/docker) - Production Docker Compose setup
+- [Vulnerability Scanning](/docs/security/scanning) - Security scanning configuration

--- a/src/content/docs/docs/reference/environment.mdx
+++ b/src/content/docs/docs/reference/environment.mdx
@@ -182,14 +182,14 @@ Configure Artifact Keeper using environment variables. This page provides a comp
 | `BLOCK_VULNERABLE_UPLOADS` | No | `false` | Block uploads with critical vulnerabilities |
 | `VULNERABILITY_SEVERITY_THRESHOLD` | No | `HIGH` | Severity threshold (CRITICAL, HIGH, MEDIUM, LOW) |
 
-## Monitoring
+## Monitoring & Observability
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `METRICS_ENABLED` | No | `true` | Enable Prometheus metrics |
 | `METRICS_PATH` | No | `/metrics` | Metrics endpoint path |
-| `TRACING_ENABLED` | No | `false` | Enable distributed tracing |
-| `TRACING_ENDPOINT` | No | - | Jaeger/OpenTelemetry endpoint |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | - | OTLP gRPC endpoint for distributed tracing (e.g., `http://jaeger:4317`). When unset, tracing exports are disabled and logging is stdout-only. |
+| `OTEL_SERVICE_NAME` | No | `artifact-keeper` | Service name reported in traces |
 | `AUDIT_LOG_ENABLED` | No | `true` | Enable audit logging |
 | `AUDIT_LOG_PATH` | No | `/var/log/artifact-keeper/audit.log` | Audit log file path |
 


### PR DESCRIPTION
## Summary

- Add new **Monitoring & Observability** sidebar section with 3 doc pages:
  - **Health Checks**: `/livez`, `/readyz`, `/healthz` endpoints, K8s probe configuration, Docker healthchecks, storage probe details, DB pool statistics
  - **Distributed Tracing**: OpenTelemetry setup, Jaeger quickstart, W3C `traceparent` support, production backends (Tempo, Datadog, X-Ray)
  - **Prometheus Metrics**: Full metric reference (HTTP, artifacts, DB pool, backups, scanning), ServiceMonitor manifest, alerting rules
- Update existing pages to use new probe endpoints:
  - `deployment/kubernetes.mdx`: `/livez` for liveness, `/readyz` for readiness + startup probe
  - `reference/environment.mdx`: Replace `TRACING_ENABLED`/`TRACING_ENDPOINT` with `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME`
  - `getting-started/quickstart.mdx`: Add `/livez` and `/readyz` health check examples

Companion to backend PR: https://github.com/artifact-keeper/artifact-keeper/pull/147

## Test plan

- [x] `npm run build` passes (48 pages, 0 errors)
- [x] All 3 new pages render correctly in sidebar under "Monitoring & Observability"
- [ ] Verify links to monitoring pages work from updated K8s and quickstart pages