### PR TITLE
docs: add remote/virtual repository sections to all format guides

### DIFF
--- a/src/content/docs/docs/guides/cargo.mdx
+++ b/src/content/docs/docs/guides/cargo.mdx
@@ -552,6 +552,59 @@ cargo doc --no-deps
 cargo package --list
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for crates.io or aggregate multiple Cargo registries behind a single URL.
+
+### Pull-Through Cache
+
+Create a remote repository to cache crates from crates.io:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "cargo-remote",
+    "name": "Cargo Remote",
+    "format": "cargo",
+    "repo_type": "remote",
+    "upstream_url": "https://crates.io"
+  }'
+```
+
+Configure Cargo to use the remote repository in `.cargo/config.toml`:
+
+```toml
+[registries.cache]
+index = "sparse+http://localhost:8080/cargo/cargo-remote/index/"
+```
+
+### Virtual Repository
+
+Combine internal crates with a crates.io cache:
+
+```bash
+# Create virtual repository
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"cargo-virtual","name":"Cargo Virtual","format":"cargo","repo_type":"virtual"}'
+
+# Add local repo first, remote as fallback
+curl -X POST http://localhost:8080/api/v1/repositories/cargo-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"cargo-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/cargo-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"cargo-remote","priority":2}'
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for Rust crates

--- a/src/content/docs/docs/guides/composer.mdx
+++ b/src/content/docs/docs/guides/composer.mdx
@@ -785,6 +785,63 @@ git add composer.lock
 composer.lock
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for Packagist or aggregate multiple Composer repositories.
+
+### Pull-Through Cache
+
+Create a remote repository to cache packages from Packagist:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "composer-remote",
+    "name": "Packagist Remote",
+    "format": "composer",
+    "repo_type": "remote",
+    "upstream_url": "https://repo.packagist.org"
+  }'
+```
+
+Configure Composer to use the cache in `composer.json`:
+
+```json
+{
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "http://localhost:8080/composer/composer-remote/"
+    }
+  ]
+}
+```
+
+### Virtual Repository
+
+Combine internal packages with a Packagist cache:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"composer-virtual","name":"Composer Virtual","format":"composer","repo_type":"virtual"}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/composer-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"composer-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/composer-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"composer-remote","priority":2}'
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for Composer packages

--- a/src/content/docs/docs/guides/cpp.mdx
+++ b/src/content/docs/docs/guides/cpp.mdx
@@ -431,6 +431,56 @@ cat ~/.netrc
 curl -n https://artifacts.example.com/bazel/main
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for Conan Center or aggregate multiple Conan remotes.
+
+### Pull-Through Cache
+
+Create a remote repository to cache packages from Conan Center:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "conan-remote",
+    "name": "Conan Center Remote",
+    "format": "conan",
+    "repo_type": "remote",
+    "upstream_url": "https://center.conan.io"
+  }'
+```
+
+Add the remote to Conan:
+
+```bash
+conan remote add ak-cache http://localhost:8080/conan/conan-remote/
+```
+
+### Virtual Repository
+
+Combine internal recipes with a Conan Center cache:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"conan-virtual","name":"Conan Virtual","format":"conan","repo_type":"virtual"}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/conan-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"conan-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/conan-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"conan-remote","priority":2}'
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## Next Steps
 
 - Learn about [repository management](/docs/concepts/repositories)

--- a/src/content/docs/docs/guides/docker.mdx
+++ b/src/content/docs/docs/guides/docker.mdx
@@ -257,6 +257,10 @@ Configure rate limits per user or repository to prevent abuse:
 curl -I http://localhost:8080/v2/myapp/manifests/latest
 ```
 
+## Remote & Virtual Repositories
+
+Remote proxy and virtual repository support for Docker/OCI images is planned but not yet available. For other package formats, Artifact Keeper supports pull-through caching and virtual aggregation — see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide for details.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for container images

--- a/src/content/docs/docs/guides/go.mdx
+++ b/src/content/docs/docs/guides/go.mdx
@@ -754,6 +754,60 @@ retract (
 )
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for the Go module proxy or aggregate multiple Go module sources.
+
+### Pull-Through Cache
+
+Create a remote repository to cache modules from proxy.golang.org:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "go-remote",
+    "name": "Go Remote",
+    "format": "go",
+    "repo_type": "remote",
+    "upstream_url": "https://proxy.golang.org"
+  }'
+```
+
+Set the `GOPROXY` environment variable:
+
+```bash
+export GOPROXY=http://localhost:8080/go/go-remote/,direct
+```
+
+### Virtual Repository
+
+Combine internal modules with the public proxy cache:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"go-virtual","name":"Go Virtual","format":"go","repo_type":"virtual"}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/go-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"go-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/go-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"go-remote","priority":2}'
+```
+
+```bash
+export GOPROXY=http://localhost:8080/go/go-virtual/,direct
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for Go modules

--- a/src/content/docs/docs/guides/helm.mdx
+++ b/src/content/docs/docs/guides/helm.mdx
@@ -666,6 +666,57 @@ To access the application:
 {{- end }}
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for public Helm chart repositories or aggregate multiple chart sources.
+
+### Pull-Through Cache
+
+Create a remote repository to cache charts from a public repository:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "helm-remote",
+    "name": "Helm Remote",
+    "format": "helm",
+    "repo_type": "remote",
+    "upstream_url": "https://charts.helm.sh/stable"
+  }'
+```
+
+Add the remote repository to Helm:
+
+```bash
+helm repo add ak-cache http://localhost:8080/helm/helm-remote/
+helm repo update
+```
+
+### Virtual Repository
+
+Combine internal charts with a public chart cache:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"helm-virtual","name":"Helm Virtual","format":"helm","repo_type":"virtual"}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/helm-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"helm-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/helm-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"helm-remote","priority":2}'
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for container images in Helm charts

--- a/src/content/docs/docs/guides/infrastructure.mdx
+++ b/src/content/docs/docs/guides/infrastructure.mdx
@@ -913,6 +913,34 @@ Include complete metadata:
 - License information
 - Source repository and documentation links
 
+## Remote & Virtual Repositories
+
+All infrastructure formats support remote proxy and virtual repository aggregation for caching modules from public registries.
+
+### Common Upstream URLs
+
+| Format | Upstream URL |
+|--------|-------------|
+| Terraform | `https://registry.terraform.io` |
+| Ansible | `https://galaxy.ansible.com` |
+
+### Example: Terraform Pull-Through Cache
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "terraform-remote",
+    "name": "Terraform Remote",
+    "format": "terraform",
+    "repo_type": "remote",
+    "upstream_url": "https://registry.terraform.io"
+  }'
+```
+
+Virtual repositories can combine internal and cached modules. See the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide for full details on cache TTL, priority ordering, and monitoring.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning

--- a/src/content/docs/docs/guides/maven.mdx
+++ b/src/content/docs/docs/guides/maven.mdx
@@ -455,6 +455,70 @@ Or clear local cache:
 rm -rf ~/.m2/repository/com/example/myapp
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for Maven Central or aggregate multiple Maven repositories behind a single URL.
+
+### Pull-Through Cache
+
+Create a remote repository to cache artifacts from Maven Central:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "maven-remote",
+    "name": "Maven Central Remote",
+    "format": "maven",
+    "repo_type": "remote",
+    "upstream_url": "https://repo1.maven.org/maven2"
+  }'
+```
+
+Add the remote repository to your `settings.xml` or `pom.xml`:
+
+```xml
+<repository>
+  <id>artifact-keeper-cache</id>
+  <url>http://localhost:8080/maven/maven-remote/</url>
+</repository>
+```
+
+### Virtual Repository
+
+Combine internal artifacts with a Maven Central cache:
+
+```bash
+# Create virtual repository
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"maven-virtual","name":"Maven Virtual","format":"maven","repo_type":"virtual"}'
+
+# Add local repo first, remote as fallback
+curl -X POST http://localhost:8080/api/v1/repositories/maven-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"maven-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/maven-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"maven-remote","priority":2}'
+```
+
+Use the virtual repository as a single source:
+
+```xml
+<repository>
+  <id>artifact-keeper</id>
+  <url>http://localhost:8080/maven/maven-virtual/</url>
+</repository>
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for Java dependencies

--- a/src/content/docs/docs/guides/more-formats.mdx
+++ b/src/content/docs/docs/guides/more-formats.mdx
@@ -610,6 +610,34 @@ jobs:
 - Rotate tokens regularly
 - Never commit tokens to source control
 
+## Remote & Virtual Repositories
+
+All formats on this page support remote proxy and virtual repository aggregation.
+
+### Common Upstream URLs
+
+| Format | Upstream URL |
+|--------|-------------|
+| CocoaPods | `https://cdn.cocoapods.org` |
+| Pub (Dart/Flutter) | `https://pub.dev` |
+
+### Example: CocoaPods Pull-Through Cache
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "cocoapods-remote",
+    "name": "CocoaPods Remote",
+    "format": "cocoapods",
+    "repo_type": "remote",
+    "upstream_url": "https://cdn.cocoapods.org"
+  }'
+```
+
+Virtual repositories can combine internal and cached packages for any of these formats. See the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide for full setup instructions.
+
 ## Next Steps
 
 - Learn about [repository management](/docs/concepts/repositories)

--- a/src/content/docs/docs/guides/more-languages.mdx
+++ b/src/content/docs/docs/guides/more-languages.mdx
@@ -437,6 +437,40 @@ conda create -n myenv \
 
 ---
 
+## Remote & Virtual Repositories
+
+All formats covered on this page support remote proxy and virtual repository aggregation.
+
+### Common Upstream URLs
+
+| Format | Upstream URL |
+|--------|-------------|
+| Hex (Elixir/Erlang) | `https://repo.hex.pm` |
+| CRAN (R) | `https://cran.r-project.org` |
+| Conda | `https://repo.anaconda.com/pkgs/main` |
+| Sbt (Scala) | `https://repo1.maven.org/maven2` |
+
+### Example: Hex Pull-Through Cache
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "hex-remote",
+    "name": "Hex Remote",
+    "format": "hex",
+    "repo_type": "remote",
+    "upstream_url": "https://repo.hex.pm"
+  }'
+```
+
+```bash
+mix hex.repo add ak-cache http://localhost:8080/hex/hex-remote/
+```
+
+Virtual repositories can combine internal and cached packages for any of these formats. See the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide for full setup instructions, cache TTL configuration, and priority ordering.
+
 ## See Also
 
 - [Security Scanning](/docs/security/scanning) - Configure vulnerability scanning for packages

--- a/src/content/docs/docs/guides/npm.mdx
+++ b/src/content/docs/docs/guides/npm.mdx
@@ -530,6 +530,64 @@ coverage
 node_modules
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for npmjs.org or aggregate multiple npm registries behind a single URL.
+
+### Pull-Through Cache
+
+Create a remote repository to cache packages from the public npm registry:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "npm-remote",
+    "name": "npm Remote",
+    "format": "npm",
+    "repo_type": "remote",
+    "upstream_url": "https://registry.npmjs.org"
+  }'
+```
+
+Point npm at the remote repository:
+
+```bash
+npm config set registry http://localhost:8080/npm-remote/
+```
+
+### Virtual Repository
+
+Combine internal packages with the npm cache:
+
+```bash
+# Create virtual repository
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"npm-virtual","name":"npm Virtual","format":"npm","repo_type":"virtual"}'
+
+# Add local repo first, remote as fallback
+curl -X POST http://localhost:8080/api/v1/repositories/npm-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"npm-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/npm-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"npm-remote","priority":2}'
+```
+
+Configure npm/yarn/pnpm to use the virtual repository:
+
+```ini
+registry=http://localhost:8080/npm-virtual/
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for npm packages

--- a/src/content/docs/docs/guides/nuget.mdx
+++ b/src/content/docs/docs/guides/nuget.mdx
@@ -801,6 +801,57 @@ Use package lock files for reproducible builds:
 </PropertyGroup>
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for nuget.org or aggregate multiple NuGet feeds behind a single source.
+
+### Pull-Through Cache
+
+Create a remote repository to cache packages from nuget.org:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "nuget-remote",
+    "name": "NuGet Remote",
+    "format": "nuget",
+    "repo_type": "remote",
+    "upstream_url": "https://api.nuget.org"
+  }'
+```
+
+Add the remote feed as a NuGet source:
+
+```bash
+dotnet nuget add source http://localhost:8080/nuget/nuget-remote/v3/index.json \
+  --name artifact-keeper-cache
+```
+
+### Virtual Repository
+
+Combine internal packages with a nuget.org cache:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"nuget-virtual","name":"NuGet Virtual","format":"nuget","repo_type":"virtual"}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/nuget-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"nuget-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/nuget-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"nuget-remote","priority":2}'
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/docs/security/scanning) - Automatic vulnerability scanning for NuGet packages

--- a/src/content/docs/docs/guides/protobuf.mdx
+++ b/src/content/docs/docs/guides/protobuf.mdx
@@ -374,6 +374,50 @@ curl -H "Authorization: Bearer $TOKEN" ...
 curl -u "admin:password" ...
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for a protobuf/BSR registry or aggregate multiple module sources.
+
+### Pull-Through Cache
+
+Create a remote repository to cache modules from a BSR-compatible registry:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "proto-remote",
+    "name": "Protobuf Remote",
+    "format": "protobuf",
+    "repo_type": "remote",
+    "upstream_url": "https://buf.build"
+  }'
+```
+
+### Virtual Repository
+
+Combine internal modules with a remote cache:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"proto-virtual","name":"Protobuf Virtual","format":"protobuf","repo_type":"virtual"}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/proto-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"proto-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/proto-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"proto-remote","priority":2}'
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/docs/security/scanning/) — Vulnerability scanning for dependencies

--- a/src/content/docs/docs/guides/pypi.mdx
+++ b/src/content/docs/docs/guides/pypi.mdx
@@ -582,6 +582,71 @@ __pycache__/
 .venv/
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for PyPI or aggregate multiple Python repositories behind a single URL.
+
+### Pull-Through Cache
+
+Create a remote repository to cache packages from PyPI:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "pypi-remote",
+    "name": "PyPI Remote",
+    "format": "pypi",
+    "repo_type": "remote",
+    "upstream_url": "https://pypi.org"
+  }'
+```
+
+Then point pip at the remote repository:
+
+```bash
+pip install --index-url http://localhost:8080/pypi-remote/simple my-package
+```
+
+Packages are fetched from PyPI on first request and cached locally. Subsequent installs are served from the cache.
+
+### Virtual Repository
+
+Combine your internal packages with a PyPI cache behind one URL:
+
+```bash
+# Create virtual repository
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"python","name":"Python Virtual","format":"pypi","repo_type":"virtual"}'
+
+# Add local repo (checked first)
+curl -X POST http://localhost:8080/api/v1/repositories/python/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"pypi-local","priority":1}'
+
+# Add remote cache (fallback)
+curl -X POST http://localhost:8080/api/v1/repositories/python/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"pypi-remote","priority":2}'
+```
+
+Configure pip to use the virtual repository:
+
+```ini
+[global]
+index-url = http://localhost:8080/python/simple
+trusted-host = localhost
+```
+
+Internal packages resolve first, public packages are transparently cached from PyPI.
+
+For full details on cache TTL configuration, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for Python packages

--- a/src/content/docs/docs/guides/rubygems.mdx
+++ b/src/content/docs/docs/guides/rubygems.mdx
@@ -819,6 +819,56 @@ Follow Ruby naming conventions:
 - Module names use CamelCase: `MyAwesomeGem`
 - Avoid conflicts with standard library
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for RubyGems.org or aggregate multiple gem sources.
+
+### Pull-Through Cache
+
+Create a remote repository to cache gems from RubyGems.org:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "gems-remote",
+    "name": "RubyGems Remote",
+    "format": "rubygems",
+    "repo_type": "remote",
+    "upstream_url": "https://rubygems.org"
+  }'
+```
+
+Configure Bundler or gem to use the cache:
+
+```bash
+bundle config mirror.https://rubygems.org http://localhost:8080/rubygems/gems-remote/
+```
+
+### Virtual Repository
+
+Combine internal gems with a RubyGems.org cache:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"key":"gems-virtual","name":"RubyGems Virtual","format":"rubygems","repo_type":"virtual"}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/gems-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"gems-local","priority":1}'
+
+curl -X POST http://localhost:8080/api/v1/repositories/gems-virtual/members \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"member_key":"gems-remote","priority":2}'
+```
+
+For full details on cache TTL, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
+
 ## See Also
 
 - [Security Scanning](/security/scanning) - Automatic vulnerability scanning for Ruby gems

--- a/src/content/docs/docs/guides/system-packages.mdx
+++ b/src/content/docs/docs/guides/system-packages.mdx
@@ -643,6 +643,56 @@ Always test packages in a staging environment:
 /debian/unstable      # Development builds
 ```
 
+## Remote & Virtual Repositories
+
+Use Artifact Keeper as a pull-through cache for public system package repositories or aggregate multiple package sources.
+
+Remote proxy and virtual repository support is available for all system package formats: RPM (yum/dnf), Debian (apt), and Alpine (apk).
+
+### Pull-Through Cache Examples
+
+```bash
+# RPM - cache from CentOS/EPEL
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "rpm-remote",
+    "name": "RPM Remote",
+    "format": "rpm",
+    "repo_type": "remote",
+    "upstream_url": "https://mirror.centos.org/centos/8/BaseOS/x86_64/os"
+  }'
+
+# Debian - cache from Ubuntu archive
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "deb-remote",
+    "name": "Debian Remote",
+    "format": "debian",
+    "repo_type": "remote",
+    "upstream_url": "http://archive.ubuntu.com/ubuntu"
+  }'
+
+# Alpine - cache from Alpine Linux
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "key": "alpine-remote",
+    "name": "Alpine Remote",
+    "format": "alpine",
+    "repo_type": "remote",
+    "upstream_url": "https://dl-cdn.alpinelinux.org/alpine"
+  }'
+```
+
+### Virtual Repositories
+
+Combine internal and cached packages behind a single source for each format. See the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide for full details on setting up virtual repositories, cache TTL, and priority ordering.
+
 ## See Also
 
 - [Repository Signing](/docs/security/signing/) - Sign packages and repository metadata


### PR DESCRIPTION
## Summary

- Adds a **"Remote & Virtual Repositories"** section to all 16 format-specific guides
- Each section includes pull-through cache creation, upstream URL, native client configuration, and virtual repository aggregation examples
- All sections link back to the central [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide

### Formats covered

| Guide | Upstream |
|-------|----------|
| PyPI | pypi.org |
| npm | registry.npmjs.org |
| Cargo | crates.io |
| Maven | repo1.maven.org |
| Go | proxy.golang.org |
| NuGet | api.nuget.org |
| RubyGems | rubygems.org |
| Composer | repo.packagist.org |
| Helm | charts.helm.sh/stable |
| Docker | *(noted as planned)* |
| Protobuf | buf.build |
| C++ (Conan) | center.conan.io |
| System Packages | CentOS/Ubuntu/Alpine mirrors |
| More Languages | Hex/CRAN/Conda/Sbt |
| Infrastructure | Terraform/Ansible registries |
| More Formats | CocoaPods/Pub |

## Test plan

- [x] `npm run build` passes (51 pages, 0 errors)
- [ ] Spot-check rendered sections for correct upstream URLs and client config