### PR TITLE
Add CLI reference, quick-start guide, and CI/CD docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
             { label: 'Quickstart', slug: 'docs/getting-started/quickstart' },
             { label: 'Installation', slug: 'docs/getting-started/installation' },
             { label: 'Configuration', slug: 'docs/getting-started/configuration' },
+            { label: 'CLI Quick Start', slug: 'docs/guides/cli-quickstart' },
           ],
         },
         {
@@ -107,8 +108,10 @@ export default defineConfig({
           label: 'Reference',
           items: [
             { label: 'REST API', slug: 'docs/reference/api' },
+            { label: 'CLI Reference (ak)', slug: 'docs/reference/ak-cli' },
             { label: 'Client Configuration', slug: 'docs/reference/cli' },
             { label: 'Environment Variables', slug: 'docs/reference/environment' },
+            { label: 'CI/CD Integration', slug: 'docs/guides/ci-cd' },
           ],
         },
       ],

--- a/src/content/docs/docs/guides/ci-cd.mdx
+++ b/src/content/docs/docs/guides/ci-cd.mdx
@@ -1,0 +1,220 @@
+---
+title: "CI/CD Integration"
+description: "Use the Artifact Keeper CLI in CI/CD pipelines"
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+The `ak` CLI is designed for CI/CD environments with non-interactive mode, JSON output, and token-based authentication.
+
+## Environment Setup
+
+Set these environment variables in your CI pipeline:
+
+```bash
+AK_INSTANCE=prod                  # Instance name or URL
+AK_TOKEN=your-api-token           # API token for authentication
+AK_NO_INPUT=1                     # Disable interactive prompts
+AK_FORMAT=json                    # Machine-readable output (optional)
+```
+
+## GitHub Actions
+
+### Install and Push Artifacts
+
+```yaml
+name: Publish
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: make build
+
+      - name: Install ak
+        run: curl -fsSL https://raw.githubusercontent.com/artifact-keeper/artifact-keeper-cli/main/install.sh | sh
+
+      - name: Configure ak
+        run: |
+          ak instance add prod "${{ secrets.AK_URL }}"
+        env:
+          AK_TOKEN: ${{ secrets.AK_TOKEN }}
+          AK_NO_INPUT: "1"
+
+      - name: Push artifact
+        run: ak artifact push my-repo ./dist/package-*.tar.gz
+        env:
+          AK_TOKEN: ${{ secrets.AK_TOKEN }}
+          AK_NO_INPUT: "1"
+```
+
+### Configure Package Manager
+
+```yaml
+- name: Configure npm
+  run: ak setup npm --repo my-npm-repo
+  env:
+    AK_TOKEN: ${{ secrets.AK_TOKEN }}
+    AK_NO_INPUT: "1"
+
+- name: Install dependencies
+  run: npm install
+
+- name: Publish
+  run: npm publish
+```
+
+### Security Scan After Upload
+
+```yaml
+- name: Upload artifact
+  run: ak artifact push my-repo ./build/app.jar
+
+- name: Trigger scan
+  run: ak scan run my-repo app.jar
+  env:
+    AK_TOKEN: ${{ secrets.AK_TOKEN }}
+    AK_FORMAT: json
+```
+
+## GitLab CI
+
+```yaml
+variables:
+  AK_TOKEN: ${AK_TOKEN}
+  AK_NO_INPUT: "1"
+
+.install-ak:
+  before_script:
+    - curl -fsSL https://raw.githubusercontent.com/artifact-keeper/artifact-keeper-cli/main/install.sh | sh
+    - ak instance add prod ${AK_URL}
+
+publish:
+  extends: .install-ak
+  stage: deploy
+  script:
+    - ak artifact push my-repo ./dist/*.tar.gz
+  only:
+    - tags
+```
+
+## Jenkins
+
+### Declarative Pipeline
+
+```groovy
+pipeline {
+    agent any
+
+    environment {
+        AK_TOKEN = credentials('artifact-keeper-token')
+        AK_NO_INPUT = '1'
+    }
+
+    stages {
+        stage('Install ak') {
+            steps {
+                sh 'curl -fsSL https://raw.githubusercontent.com/artifact-keeper/artifact-keeper-cli/main/install.sh | sh'
+                sh 'ak instance add prod ${AK_URL}'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                sh 'make build'
+            }
+        }
+
+        stage('Publish') {
+            steps {
+                sh 'ak artifact push my-repo ./dist/*.tar.gz'
+            }
+        }
+
+        stage('Scan') {
+            steps {
+                sh 'ak scan run my-repo dist/app.tar.gz'
+            }
+        }
+    }
+}
+```
+
+## Docker-based CI
+
+If your CI runs in Docker containers, use the `ak` Docker image:
+
+```yaml
+# GitHub Actions
+- name: Push artifact
+  run: |
+    docker run --rm \
+      -e AK_TOKEN=${{ secrets.AK_TOKEN }} \
+      -e AK_NO_INPUT=1 \
+      -v $(pwd)/dist:/dist \
+      ghcr.io/artifact-keeper/ak:latest \
+      artifact push my-repo /dist/package.tar.gz
+```
+
+## Promotion Pipeline
+
+Use `ak artifact copy` to promote artifacts between repositories:
+
+```yaml
+stages:
+  - build
+  - test
+  - promote
+
+build:
+  script:
+    - make build
+    - ak artifact push staging-repo ./build/app.tar.gz
+
+test:
+  script:
+    - ak artifact pull staging-repo app.tar.gz
+    - make test
+
+promote:
+  script:
+    - ak artifact copy staging-repo/app.tar.gz release-repo/app.tar.gz
+  when: manual
+```
+
+## Bulk Migration
+
+Use `ak migrate` to move artifacts between instances during registry migrations:
+
+```bash
+# Preview what would be migrated
+ak migrate \
+  --from-instance old-registry \
+  --from-repo npm-local \
+  --to-instance new-registry \
+  --to-repo npm-local \
+  --dry-run
+
+# Execute migration
+ak migrate \
+  --from-instance old-registry \
+  --from-repo npm-local \
+  --to-instance new-registry \
+  --to-repo npm-local
+```
+
+## Best Practices
+
+1. **Use API tokens**, not passwords — create scoped tokens with the minimum required permissions
+2. **Set `AK_NO_INPUT=1`** in all CI environments to prevent hanging on prompts
+3. **Use `--format json`** when parsing output in scripts
+4. **Pin the CLI version** by downloading a specific release instead of using `install.sh`
+5. **Store credentials as secrets** — never commit tokens to your repository
+6. **Use `ak doctor`** in your pipeline setup to verify connectivity before running commands

--- a/src/content/docs/docs/guides/cli-quickstart.mdx
+++ b/src/content/docs/docs/guides/cli-quickstart.mdx
@@ -1,0 +1,158 @@
+---
+title: "CLI Quick Start"
+description: "Get up and running with the Artifact Keeper CLI in 5 minutes"
+---
+
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+
+Get up and running with `ak` — the Artifact Keeper CLI.
+
+<Steps>
+
+1. **Install the CLI**
+
+   <Tabs>
+   <TabItem label="curl">
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/artifact-keeper/artifact-keeper-cli/main/install.sh | sh
+   ```
+   </TabItem>
+   <TabItem label="Homebrew">
+   ```bash
+   brew install artifact-keeper/tap/ak
+   ```
+   </TabItem>
+   <TabItem label="Cargo">
+   ```bash
+   cargo install artifact-keeper-cli
+   ```
+   </TabItem>
+   </Tabs>
+
+   Verify:
+
+   ```bash
+   ak --version
+   ```
+
+2. **Add your registry instance**
+
+   ```bash
+   ak instance add myserver https://registry.company.com
+   ```
+
+   This saves the server URL locally and sets it as your default instance.
+
+3. **Log in**
+
+   ```bash
+   ak auth login
+   ```
+
+   This opens a browser for authentication. For CI/headless environments, use token auth:
+
+   ```bash
+   ak auth login --token
+   ```
+
+4. **Browse repositories**
+
+   ```bash
+   ak repo list
+   ```
+
+   Filter by format:
+
+   ```bash
+   ak repo list --format npm
+   ak repo list --format docker
+   ```
+
+5. **Upload an artifact**
+
+   ```bash
+   ak artifact push my-repo ./my-package-1.0.0.tar.gz
+   ```
+
+   Upload multiple files with glob patterns:
+
+   ```bash
+   ak artifact push my-repo './dist/*.whl'
+   ```
+
+6. **Download an artifact**
+
+   ```bash
+   ak artifact pull my-repo org/my-package/1.0.0/my-package-1.0.0.jar
+   ```
+
+7. **Configure your package manager**
+
+   Auto-detect your project's toolchains and configure them all at once:
+
+   ```bash
+   ak setup auto
+   ```
+
+   Or configure individually:
+
+   ```bash
+   ak setup npm
+   ak setup pip
+   ak setup cargo
+   ```
+
+</Steps>
+
+## What's Next?
+
+- **Search artifacts**: `ak artifact search "log4j" --format maven`
+- **Run security scans**: `ak scan run my-repo path/to/artifact`
+- **Check diagnostics**: `ak doctor`
+- **Launch the TUI**: `ak tui`
+- **Set up shell completions**: `ak completion bash > ~/.bash_completion.d/ak`
+
+## Common Workflows
+
+### Multiple Instances
+
+```bash
+# Add multiple servers
+ak instance add prod https://registry.company.com
+ak instance add staging https://staging.company.com
+
+# Switch default
+ak instance use staging
+
+# Or use per-command override
+ak repo list --instance prod
+```
+
+### Output Formats
+
+```bash
+# Table (default for interactive terminals)
+ak repo list
+
+# JSON (default when piped)
+ak repo list --format json | jq '.[] | .key'
+
+# YAML
+ak repo list --format yaml
+
+# Quiet (IDs only, great for scripting)
+ak repo list --format quiet | xargs -I{} ak repo show {}
+```
+
+### Non-Interactive Mode
+
+For scripting and CI/CD:
+
+```bash
+export AK_INSTANCE=prod
+export AK_TOKEN=your-api-token
+export AK_NO_INPUT=1
+export AK_FORMAT=json
+
+ak artifact push my-repo ./build/output.tar.gz
+```

--- a/src/content/docs/docs/reference/ak-cli.mdx
+++ b/src/content/docs/docs/reference/ak-cli.mdx
@@ -1,0 +1,234 @@
+---
+title: "CLI Reference (ak)"
+description: "Complete command reference for the Artifact Keeper CLI"
+---
+
+The `ak` CLI is the official command-line tool for managing Artifact Keeper instances, repositories, and artifacts.
+
+## Installation
+
+### Curl Installer (Linux/macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/artifact-keeper/artifact-keeper-cli/main/install.sh | sh
+```
+
+### Homebrew
+
+```bash
+brew install artifact-keeper/tap/ak
+```
+
+### Cargo
+
+```bash
+cargo install artifact-keeper-cli
+```
+
+### Docker
+
+```bash
+docker run --rm ghcr.io/artifact-keeper/ak:latest --help
+```
+
+### Snap
+
+```bash
+snap install ak --classic
+```
+
+---
+
+## Global Options
+
+| Flag | Env Var | Description |
+|------|---------|-------------|
+| `--format <table\|json\|yaml\|quiet>` | `AK_FORMAT` | Output format (auto-detects: table for TTY, json for pipes) |
+| `-q, --quiet` | | Suppress all output except primary identifiers |
+| `--instance <name>` | `AK_INSTANCE` | Target instance (overrides default) |
+| `--no-input` | `AK_NO_INPUT` | Disable interactive prompts |
+| `--color <auto\|always\|never>` | `AK_COLOR` | Color output mode |
+
+---
+
+## Commands
+
+### `ak instance` — Manage Instances
+
+```bash
+ak instance add <name> <url>          # Add an instance
+ak instance remove <name>             # Remove an instance
+ak instance list                      # List all instances
+ak instance use <name>                # Set default instance
+ak instance info [name]               # Show instance details
+```
+
+### `ak auth` — Authentication
+
+```bash
+ak auth login [url]                   # Log in (browser flow)
+ak auth login --token                 # Log in with API token
+ak auth logout [instance]             # Log out
+ak auth whoami                        # Show current user
+ak auth switch                        # Switch account
+ak auth token create <name>           # Create API token
+ak auth token list                    # List API tokens
+ak auth token revoke <id>             # Revoke API token
+```
+
+### `ak repo` — Repositories
+
+```bash
+ak repo list                          # List all repositories
+ak repo list --format npm             # Filter by format
+ak repo list --type local             # Filter by type
+ak repo show <key>                    # Show repository details
+ak repo create <key> --format <fmt>   # Create repository
+ak repo delete <key>                  # Delete repository
+```
+
+### `ak artifact` — Artifacts
+
+```bash
+ak artifact push <repo> <file>...     # Upload artifacts
+ak artifact push <repo> '*.tar.gz'    # Upload with glob
+ak artifact pull <repo> <path>        # Download artifact
+ak artifact pull <repo> <path> -o f   # Download to specific file
+ak artifact list <repo>               # List artifacts
+ak artifact info <repo> <path>        # Show artifact metadata
+ak artifact delete <repo> <path>      # Delete artifact
+ak artifact search "query"            # Search across repos
+ak artifact search "log4j" --format maven
+ak artifact copy src/path dst/path    # Copy within instance
+ak artifact copy s/p d/p --from-instance a --to-instance b  # Cross-instance
+```
+
+### `ak setup` — Package Manager Configuration
+
+```bash
+ak setup auto                         # Auto-detect and configure all
+ak setup npm [--repo <key>]           # Configure npm/pnpm/yarn
+ak setup pip [--repo <key>]           # Configure pip/poetry
+ak setup cargo [--repo <key>]         # Configure Cargo
+ak setup docker [--repo <key>]        # Configure Docker
+ak setup maven [--repo <key>]         # Configure Maven
+ak setup gradle [--repo <key>]        # Configure Gradle
+ak setup go [--repo <key>]            # Configure Go modules
+ak setup helm [--repo <key>]          # Configure Helm
+```
+
+### `ak scan` — Security Scanning
+
+```bash
+ak scan run <repo> <path>             # Trigger a scan
+ak scan list [--repo <key>]           # List recent scans
+ak scan show <scan-id>                # Show scan findings
+```
+
+### `ak admin` — Administration
+
+```bash
+# Backups
+ak admin backup list                  # List backups
+ak admin backup create [--type full]  # Create backup
+ak admin backup restore <id>          # Restore from backup
+
+# Cleanup
+ak admin cleanup --audit-logs         # Clean old audit logs
+ak admin cleanup --old-backups        # Clean old backups
+ak admin cleanup --stale-peers        # Mark stale peers offline
+
+# Metrics
+ak admin metrics                      # Show server metrics
+
+# Users
+ak admin users list                   # List users
+ak admin users create <user> --email <email>  # Create user
+ak admin users delete <id>            # Delete user
+
+# Plugins
+ak admin plugins list                 # List installed plugins
+ak admin plugins install <git-url>    # Install from git
+ak admin plugins remove <id>          # Uninstall plugin
+```
+
+### `ak migrate` — Bulk Migration
+
+```bash
+ak migrate --from-instance old --from-repo npm --to-repo npm-prod
+ak migrate --from-instance staging --from-repo libs --to-repo libs --dry-run
+```
+
+### `ak doctor` — Diagnostics
+
+```bash
+ak doctor                             # Run all diagnostics
+```
+
+Checks configuration, instance connectivity, auth token validity, and package manager detection.
+
+### `ak config` — CLI Configuration
+
+```bash
+ak config list                        # Show all settings
+ak config get <key>                   # Get a setting
+ak config set <key> <value>           # Set a setting
+```
+
+### `ak tui` — Interactive Dashboard
+
+```bash
+ak tui                                # Launch TUI
+```
+
+Three-panel layout showing instances, repositories, and artifacts. Navigate with `hjkl`/arrows, `Tab` to switch panels, `/` to search, `i` for details, `?` for help.
+
+### `ak completion` — Shell Completions
+
+```bash
+ak completion bash > ~/.bash_completion.d/ak
+ak completion zsh > ~/.zfunc/_ak
+ak completion fish > ~/.config/fish/completions/ak.fish
+ak completion powershell > ak.ps1
+```
+
+### `ak man-pages` — Man Page Generation
+
+```bash
+ak man-pages ./man                    # Generate man pages
+sudo cp man/*.1 /usr/local/share/man/man1/
+```
+
+---
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `AK_FORMAT` | Default output format |
+| `AK_INSTANCE` | Override default instance |
+| `AK_NO_INPUT` | Disable interactive prompts |
+| `AK_COLOR` | Color mode (auto/always/never) |
+| `AK_CONFIG_DIR` | Override config directory (default: `~/.config/artifact-keeper/`) |
+| `AK_TOKEN` | API token (alternative to keychain) |
+| `NO_COLOR` | Standard no-color flag |
+
+---
+
+## Configuration
+
+Configuration is stored in `~/.config/artifact-keeper/config.toml`:
+
+```toml
+default_instance = "prod"
+
+[instances.prod]
+url = "https://registry.company.com"
+api_version = "v1"
+
+[instances.staging]
+url = "https://staging-registry.company.com"
+api_version = "v1"
+```
+
+Credentials are stored securely in the OS keychain (macOS Keychain, Linux Secret Service, Windows Credential Manager).


### PR DESCRIPTION
## Summary
- **CLI Reference**: Complete command reference for all `ak` subcommands, global options, and environment variables
- **CLI Quick Start**: 5-minute guide covering install, login, browse repos, push/pull artifacts, and setup
- **CI/CD Integration**: GitHub Actions, GitLab CI, and Jenkins pipeline examples with best practices
- **Sidebar**: Added entries under Getting Started and Reference sections