### PR TITLE
Fix quickstart download URLs and add Podman support

### DIFF
--- a/src/content/docs/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/docs/getting-started/quickstart.mdx
@@ -9,7 +9,7 @@ Get Artifact Keeper up and running in minutes using Docker Compose.
 
 ## Prerequisites
 
-- Docker and Docker Compose installed
+- Docker and Docker Compose (or Podman with `podman-compose`) installed
 
 ## Quick Start
 
@@ -18,9 +18,20 @@ Get Artifact Keeper up and running in minutes using Docker Compose.
 ```bash
 mkdir artifact-keeper && cd artifact-keeper
 curl -fsSLO https://raw.githubusercontent.com/artifact-keeper/artifact-keeper/main/docker-compose.yml
-curl -fsSLO https://raw.githubusercontent.com/artifact-keeper/artifact-keeper/main/Caddyfile
+mkdir docker
+curl -fsSLo docker/Caddyfile https://raw.githubusercontent.com/artifact-keeper/artifact-keeper/main/docker/Caddyfile
+curl -fsSLo docker/init-db.sql https://raw.githubusercontent.com/artifact-keeper/artifact-keeper/main/docker/init-db.sql
+curl -fsSLo docker/init-pg-ssl.sh https://raw.githubusercontent.com/artifact-keeper/artifact-keeper/main/docker/init-pg-ssl.sh
+curl -fsSLo docker/init-dtrack.sh https://raw.githubusercontent.com/artifact-keeper/artifact-keeper/main/docker/init-dtrack.sh
 docker compose up -d
 ```
+
+:::note[Using Podman?]
+Replace `docker compose` with `podman-compose`. Podman 4.4+ with podman-compose 1.0+ is supported. If running rootless Podman on RHEL/Fedora, enable linger so containers persist after logout:
+```bash
+sudo loginctl enable-linger $USER
+```
+:::
 
 This starts the full stack:
 - **Backend** — Rust API server with 45+ format handlers


### PR DESCRIPTION
## Summary
- Fix Caddyfile download URL (was missing `/docker/` path, caused 404)
- Add downloads for all required bind-mounted files (`init-db.sql`, `init-pg-ssl.sh`, `init-dtrack.sh`) into correct `docker/` subdirectory
- Add Podman as alternative in prerequisites
- Add note about `loginctl enable-linger` for rootless Podman on RHEL/Fedora

## Test plan
- [x] Verified all download URLs resolve correctly
- [x] Tested full quickstart flow on RHEL 8.10 with Podman
- [x] Confirmed stack starts and `/health` returns healthy

Related: artifact-keeper/artifact-keeper#194