### PR TITLE
docs: add Incus/LXC container image format guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,6 +37,7 @@ export default defineConfig({
           items: [
             { label: 'Overview', slug: 'docs/package-formats' },
             { label: 'Docker / OCI', slug: 'docs/guides/docker' },
+            { label: 'Incus / LXC', slug: 'docs/guides/incus' },
             { label: 'Maven', slug: 'docs/guides/maven' },
             { label: 'npm', slug: 'docs/guides/npm' },
             { label: 'PyPI', slug: 'docs/guides/pypi' },

--- a/src/content/docs/docs/guides/incus.mdx
+++ b/src/content/docs/docs/guides/incus.mdx
@@ -1,0 +1,275 @@
+---
+title: "Incus/LXC Container Image Guide"
+description: "Hosting Incus and LXC container images with SimpleStreams protocol support"
+---
+
+Artifact Keeper can serve as a private image server for [Incus](https://linuxcontainers.org/incus/) and [LXC](https://linuxcontainers.org/lxc/) container and virtual machine images using the [SimpleStreams](https://launchpad.net/simplestreams) discovery protocol.
+
+## Endpoint
+
+All Incus operations use the `/incus` endpoint:
+
+```
+http://localhost:8080/incus/{repository-key}
+```
+
+SimpleStreams discovery:
+- `GET /incus/{repo}/streams/v1/index.json` — SimpleStreams index
+- `GET /incus/{repo}/streams/v1/images.json` — Product catalog
+
+Image operations:
+- `GET /incus/{repo}/images/{product}/{version}/{file}` — Download
+- `PUT /incus/{repo}/images/{product}/{version}/{file}` — Upload
+- `DELETE /incus/{repo}/images/{product}/{version}/{file}` — Delete
+
+## Creating a Repository
+
+Create a hosted Incus repository via the API:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/repositories \
+  -u admin:password \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key": "incus-images",
+    "name": "Incus Images",
+    "format": "incus",
+    "repo_type": "hosted"
+  }'
+```
+
+Use the `lxc` format key if you want to label the repository for legacy LXC use — both formats share the same handler.
+
+## Uploading Images
+
+### Unified Tarball
+
+A unified tarball contains both `metadata.yaml` and the rootfs in a single `.tar.xz` or `.tar.gz` archive:
+
+```bash
+curl -X PUT http://localhost:8080/incus/incus-images/images/ubuntu-noble/20240215/incus.tar.xz \
+  -u admin:password \
+  -H "Content-Type: application/x-xz" \
+  --data-binary @ubuntu-noble-20240215.tar.xz
+```
+
+### Split Format
+
+Split format uploads metadata and rootfs separately:
+
+```bash
+# Upload metadata tarball
+curl -X PUT http://localhost:8080/incus/incus-images/images/debian-bookworm/20240301/metadata.tar.xz \
+  -u admin:password \
+  -H "Content-Type: application/x-xz" \
+  --data-binary @metadata.tar.xz
+
+# Upload container rootfs (squashfs)
+curl -X PUT http://localhost:8080/incus/incus-images/images/debian-bookworm/20240301/rootfs.squashfs \
+  -u admin:password \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @rootfs.squashfs
+
+# Upload VM disk image (qcow2)
+curl -X PUT http://localhost:8080/incus/incus-images/images/debian-bookworm/20240301/rootfs.img \
+  -u admin:password \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @disk.qcow2
+```
+
+### Path Layout
+
+Images follow a `{product}/{version}/{file}` structure:
+
+| Path | Description |
+|------|-------------|
+| `ubuntu-noble/20240215/incus.tar.xz` | Unified image tarball |
+| `debian-bookworm/v1.0/metadata.tar.xz` | Split: metadata tarball |
+| `debian-bookworm/v1.0/rootfs.squashfs` | Split: container rootfs |
+| `debian-bookworm/v1.0/rootfs.img` | Split: VM disk image (qcow2) |
+
+## Configuring Incus
+
+### Add as Remote Image Server
+
+Point Incus at your Artifact Keeper instance:
+
+```bash
+incus remote add myregistry http://localhost:8080/incus/incus-images \
+  --protocol simplestreams \
+  --public
+```
+
+:::note
+SimpleStreams remotes are read-only from the Incus client's perspective. Image uploads are done via the HTTP API (curl/CI).
+:::
+
+### List Available Images
+
+```bash
+incus image list myregistry:
+```
+
+### Launch a Container
+
+```bash
+incus launch myregistry:ubuntu-noble my-container
+```
+
+### Launch a Virtual Machine
+
+```bash
+incus launch myregistry:debian-bookworm my-vm --vm
+```
+
+### Import an Image Locally
+
+```bash
+incus image copy myregistry:ubuntu-noble local: --alias ubuntu-noble
+```
+
+## SimpleStreams Protocol
+
+Artifact Keeper automatically generates the SimpleStreams JSON endpoints from your uploaded images.
+
+### index.json
+
+The index at `streams/v1/index.json` lists all available product catalogs:
+
+```json
+{
+  "format": "index:1.0",
+  "index": {
+    "images": {
+      "datatype": "image-downloads",
+      "format": "products:1.0",
+      "path": "streams/v1/images.json",
+      "products": ["ubuntu-noble", "debian-bookworm"]
+    }
+  }
+}
+```
+
+### images.json
+
+The catalog at `streams/v1/images.json` describes every product, version, and downloadable file:
+
+```json
+{
+  "format": "products:1.0",
+  "products": {
+    "ubuntu-noble": {
+      "arch": "x86_64",
+      "os": "Ubuntu",
+      "release": "noble",
+      "versions": {
+        "20240215": {
+          "items": {
+            "incus.tar.xz": {
+              "ftype": "incus.tar.xz",
+              "sha256": "abc123...",
+              "path": "/incus/incus-images/images/ubuntu-noble/20240215/incus.tar.gz",
+              "size": 123456789
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Architecture, OS, and release metadata are extracted automatically from `metadata.yaml` inside uploaded tarballs.
+
+## Vulnerability Scanning
+
+Artifact Keeper scans Incus container images for OS-level package vulnerabilities using Trivy:
+
+- **Unified tarballs**: Extracted and scanned for installed packages (`.deb`, `.rpm`, etc.)
+- **SquashFS rootfs**: Extracted with `unsquashfs` and scanned
+- **QCOW2 disk images**: Not scannable (require mounting)
+- **Metadata-only tarballs**: Skipped (no rootfs to scan)
+
+Scan results appear in the Security dashboard alongside other artifact types.
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+- name: Upload Incus image
+  run: |
+    curl -X PUT \
+      -u ${{ secrets.REGISTRY_USER }}:${{ secrets.REGISTRY_PASS }} \
+      -H "Content-Type: application/x-xz" \
+      --data-binary @output/incus.tar.xz \
+      ${{ vars.REGISTRY_URL }}/incus/incus-images/images/${{ env.PRODUCT }}/${{ env.VERSION }}/incus.tar.xz
+```
+
+### GitLab CI
+
+```yaml
+upload-image:
+  stage: publish
+  script:
+    - |
+      curl -X PUT \
+        -u ${REGISTRY_USER}:${REGISTRY_PASS} \
+        -H "Content-Type: application/x-xz" \
+        --data-binary @output/incus.tar.xz \
+        ${REGISTRY_URL}/incus/incus-images/images/${PRODUCT}/${VERSION}/incus.tar.xz
+```
+
+### distrobuilder
+
+If you build images with [distrobuilder](https://linuxcontainers.org/distrobuilder/), upload the output directly:
+
+```bash
+distrobuilder build-incus ubuntu.yaml
+curl -X PUT -u admin:password \
+  -H "Content-Type: application/x-xz" \
+  --data-binary @incus.tar.xz \
+  http://localhost:8080/incus/incus-images/images/ubuntu-noble/$(date +%Y%m%d)/incus.tar.xz
+```
+
+## Deleting Images
+
+```bash
+curl -X DELETE http://localhost:8080/incus/incus-images/images/ubuntu-noble/20240215/incus.tar.xz \
+  -u admin:password
+```
+
+Deleted images are soft-deleted and no longer appear in SimpleStreams catalogs.
+
+## Troubleshooting
+
+### "Repository not found" or format mismatch
+
+Ensure the repository was created with `"format": "incus"` or `"format": "lxc"`.
+
+### Incus remote shows no images
+
+Check that images were uploaded with the correct path structure (`product/version/file`). Run `curl` against the `streams/v1/images.json` endpoint to inspect the generated catalog.
+
+### Upload returns 401
+
+Write operations require Basic authentication. Read operations (downloads, SimpleStreams discovery) are public.
+
+### Large image uploads timing out
+
+The endpoint supports uploads up to 4 GB. For very large VM images, ensure your reverse proxy (Nginx, Caddy) also allows large request bodies.
+
+## Best Practices
+
+- **Use consistent product names** that match your distro naming convention (e.g., `ubuntu-noble`, `debian-bookworm-cloud`)
+- **Use date-based versions** (e.g., `20240215`) for daily builds or semver for release images
+- **Upload both container and VM variants** under the same product/version for maximum flexibility
+- **Enable vulnerability scanning** to catch OS package CVEs in your container images
+- **Use split format** for large images where you want to update metadata without re-uploading the rootfs
+
+## See Also
+
+- [Docker / OCI Guide](/docs/guides/docker/) — OCI container registry
+- [Vulnerability Scanning](/docs/security/scanning/) — Scanning container images
+- [Artifact Signing](/docs/security/signing/) — Signing artifacts
+- [Peer Replication](/docs/advanced/replication/) — Distributing images across regions

--- a/src/content/docs/docs/package-formats.mdx
+++ b/src/content/docs/docs/package-formats.mdx
@@ -13,7 +13,7 @@ This page is a quick reference index. Click through to the detailed guide pages 
 
 ## Complete Format Reference
 
-**36 native formats** with full wire-protocol support, plus **14 aliases** for alternative clients that share an underlying protocol. Custom formats can be added at any time via [WASM plugins](/docs/advanced/plugins/).
+**37 native formats** with full wire-protocol support, plus **14 aliases** for alternative clients that share an underlying protocol. Custom formats can be added at any time via [WASM plugins](/docs/advanced/plugins/).
 
 | # | Format | Key | Category | Native Clients |
 |---|--------|-----|----------|----------------|
@@ -34,25 +34,26 @@ This page is a quick reference index. Click through to the detailed guide pages 
 | 15 | Conda | `conda_native` | Languages | conda, mamba, micromamba |
 | 16 | Protobuf / BSR | `protobuf` | Schemas | buf CLI |
 | 17 | Docker / OCI | `docker` | Containers | Docker, Podman, Buildx, ORAS |
-| 18 | Helm | `helm` | Infrastructure | helm |
-| 19 | Terraform | `terraform` | Infrastructure | terraform, tofu |
-| 20 | Vagrant | `vagrant` | Infrastructure | vagrant |
-| 21 | Chef | `chef` | Infrastructure | knife, Berkshelf |
-| 22 | Puppet | `puppet` | Infrastructure | puppet module |
-| 23 | Ansible | `ansible` | Infrastructure | ansible-galaxy |
-| 24 | Debian / APT | `debian` | System Packages | apt, dpkg |
-| 25 | RPM / YUM | `rpm` | System Packages | yum, dnf, zypper |
-| 26 | Alpine / APK | `alpine` | System Packages | apk |
-| 27 | OPKG | `opkg` | System Packages | opkg (OpenWrt) |
-| 28 | Conan | `conan` | C / C++ | conan (v2) |
-| 29 | Bazel | `bazel` | C / C++ | bazel, bazelisk |
-| 30 | HuggingFace | `huggingface` | ML / AI | huggingface_hub, transformers |
-| 31 | ML Model | `mlmodel` | ML / AI | Generic model storage |
-| 32 | VS Code | `vscode` | Editor Extensions | VS Code, Cursor, Windsurf, Kiro |
-| 33 | JetBrains | `jetbrains` | Editor Extensions | IntelliJ, PyCharm, WebStorm |
-| 34 | Git LFS | `gitlfs` | Other | git lfs |
-| 35 | P2 | `p2` | Other | Eclipse IDE |
-| 36 | Generic | `generic` | Other | curl, wget, any HTTP client |
+| 18 | Incus / LXC | `incus` | Containers | incus, lxc |
+| 19 | Helm | `helm` | Infrastructure | helm |
+| 20 | Terraform | `terraform` | Infrastructure | terraform, tofu |
+| 21 | Vagrant | `vagrant` | Infrastructure | vagrant |
+| 22 | Chef | `chef` | Infrastructure | knife, Berkshelf |
+| 23 | Puppet | `puppet` | Infrastructure | puppet module |
+| 24 | Ansible | `ansible` | Infrastructure | ansible-galaxy |
+| 25 | Debian / APT | `debian` | System Packages | apt, dpkg |
+| 26 | RPM / YUM | `rpm` | System Packages | yum, dnf, zypper |
+| 27 | Alpine / APK | `alpine` | System Packages | apk |
+| 28 | OPKG | `opkg` | System Packages | opkg (OpenWrt) |
+| 29 | Conan | `conan` | C / C++ | conan (v2) |
+| 30 | Bazel | `bazel` | C / C++ | bazel, bazelisk |
+| 31 | HuggingFace | `huggingface` | ML / AI | huggingface_hub, transformers |
+| 32 | ML Model | `mlmodel` | ML / AI | Generic model storage |
+| 33 | VS Code | `vscode` | Editor Extensions | VS Code, Cursor, Windsurf, Kiro |
+| 34 | JetBrains | `jetbrains` | Editor Extensions | IntelliJ, PyCharm, WebStorm |
+| 35 | Git LFS | `gitlfs` | Other | git lfs |
+| 36 | P2 | `p2` | Other | Eclipse IDE |
+| 37 | Generic | `generic` | Other | curl, wget, any HTTP client |
 
 ---
 
@@ -95,8 +96,9 @@ BSR-compatible Connect RPC endpoints for hosting protobuf modules with commit tr
 | Format | Key | Native Clients | Guide |
 |--------|-----|----------------|-------|
 | **Docker / OCI** | `docker` | Docker, Podman, Buildx, ORAS, Helm OCI, WASM OCI | [Docker & OCI Guide](/docs/guides/docker/) |
+| **Incus / LXC** | `incus` | incus, lxc | [Incus / LXC Guide](/docs/guides/incus/) |
 
-Full OCI Distribution Spec implementation supporting containers, WASM modules, and generic OCI artifacts.
+Full OCI Distribution Spec implementation for Docker containers, plus SimpleStreams protocol support for Incus/LXC system containers and VM images.
 
 ---
 
@@ -180,6 +182,7 @@ Many package managers share underlying protocols. These aliases automatically re
 | `poetry` | pypi | `helm_oci` | docker |
 | `conda` | pypi | `chocolatey` | nuget |
 | `powershell` | nuget | `opentofu` | terraform |
+| `lxc` | incus | | |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add comprehensive Incus/LXC guide covering SimpleStreams protocol, image upload/download, `incus remote add` configuration, vulnerability scanning, CI/CD integration
- Add sidebar navigation entry under "Package Formats"
- Update package-formats.mdx index: add row #18 (Incus/LXC), update format count to 37, add `lxc` alias, update Containers section

## Test plan
- [ ] Verify guide page renders at `/docs/guides/incus/`
- [ ] Verify sidebar shows "Incus / LXC" entry
- [ ] Verify package-formats.mdx table numbering is correct