### PR TITLE
fix: remove duplicate h1 titles on migration pages

### DIFF
--- a/src/content/docs/docs/migration/from-artifactory.mdx
+++ b/src/content/docs/docs/migration/from-artifactory.mdx
@@ -3,8 +3,6 @@ title: "Migrate from Artifactory"
 description: "Migrate your artifacts from JFrog Artifactory to Artifact Keeper with zero downtime"
 ---
 
-# Migrate from Artifactory
-
 Switch from JFrog Artifactory to Artifact Keeper and save thousands of dollars per year while gaining access to all features with no restrictions.
 
 ## Why Migrate?

--- a/src/content/docs/docs/migration/from-nexus.mdx
+++ b/src/content/docs/docs/migration/from-nexus.mdx
@@ -3,8 +3,6 @@ title: "Migrate from Nexus"
 description: "Migrate your artifacts from Sonatype Nexus Repository to Artifact Keeper"
 ---
 
-# Migrate from Nexus
-
 Switch from Sonatype Nexus Repository Manager to Artifact Keeper with the built-in migration API.
 
 ## Why Migrate?


### PR DESCRIPTION
## Summary
- Removed explicit `# Migrate from Artifactory` and `# Migrate from Nexus` headings from the migration docs
- The front matter `title` is already rendered as an h1 by Starlight, so having both caused the title to appear twice on the page

Fixes artifact-keeper/artifact-keeper#236

## Test plan
- [ ] Verify https://artifactkeeper.com/docs/migration/from-artifactory/ shows the title only once
- [ ] Verify https://artifactkeeper.com/docs/migration/from-nexus/ shows the title only once
