### PR TITLE
Rewrite plugin docs to match actual capabilities

### DIFF
--- a/src/content/docs/docs/advanced/plugins.mdx
+++ b/src/content/docs/docs/advanced/plugins.mdx
@@ -1,316 +1,178 @@
 ---
 title: "WASM Plugin System"
-description: "Hot-loadable WebAssembly plugins for custom format handlers and extensibility"
+description: "Extend Artifact Keeper with custom format handlers using WebAssembly plugins"
 ---
 
-Artifact Keeper features a powerful plugin system built on WebAssembly (WASM) that allows you to extend functionality without modifying core code.
+Artifact Keeper supports custom package format handlers via WebAssembly (WASM) plugins. If the built-in 45+ format handlers don't cover your needs, you can write a plugin that handles your custom format, compile it to WASM, and install it without modifying or rebuilding the server.
 
-## Overview
+## What plugins can do
 
-The WASM plugin system enables:
+Plugins implement the **format handler** contract. A format handler plugin can:
 
-- **Custom format handlers**: Support new package formats beyond the built-in 30+
-- **Metadata extractors**: Parse and index custom artifact metadata
-- **Validation hooks**: Implement custom artifact validation logic
-- **Post-processing**: Transform artifacts on upload (virus scanning, compression, etc.)
-- **Hot-reloading**: Install, update, and remove plugins without server restart
+- **Parse metadata** from uploaded artifacts (name, version, content type, size, checksums)
+- **Validate artifacts** before they are stored (reject malformed uploads)
+- **Generate index files** for a repository (e.g., `maven-metadata.xml`, package listings)
+- **Serve native client protocols** (v2) so that tools like `pip`, `dnf`, or `cargo` can talk directly to your custom format's API endpoints
+
+Each plugin handles exactly one format key (e.g., `unity`, `pypi-custom`, `rpm-custom`). When an artifact is uploaded to a repository backed by that plugin, Artifact Keeper delegates parsing, validation, and indexing to the plugin's WASM module.
 
 ## Architecture
 
-Built on industry-standard WebAssembly technologies:
+Plugins run inside the [Wasmtime](https://wasmtime.dev/) WebAssembly runtime. The contract between host and plugin is defined using [WebAssembly Interface Types (WIT)](https://component-model.bytecodealliance.org/design/wit.html), which provides a language-agnostic way to define function signatures and data types.
 
-- **wasmtime 21.0+**: High-performance WASM runtime
-- **WASI**: WebAssembly System Interface for secure system access
-- **wit-bindgen**: Interface type definitions for plugin contracts
-
-### Security Model
-
-Plugins run in a sandboxed environment with:
-
-- No direct filesystem access (only via provided APIs)
-- No network access (unless explicitly granted)
-- Limited memory allocation
-- CPU time limits per operation
-- Isolated from other plugins
-
-## Plugin Lifecycle
-
-### 1. Installation
-
-Install plugins from a ZIP file or Git repository:
-
-```bash
-# From local file
-curl -X POST https://registry.example.com/api/v1/plugins \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -F "file=@my-plugin.zip"
-
-# From Git repository
-curl -X POST https://registry.example.com/api/v1/plugins \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "source": "git",
-    "repository": "https://github.com/example/plugin-repo.git",
-    "ref": "v1.0.0"
-  }'
-
-# From plugin registry
-curl -X POST https://registry.example.com/api/v1/plugins \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "source": "registry",
-    "name": "format-handler-conan",
-    "version": "1.2.0"
-  }'
+```
+Plugin Source (Git/ZIP) → Manifest Validation → Wasmtime Load & Link → Format Handler Registration
 ```
 
-### 2. Enabling
+### Sandbox model
 
-Installed plugins are disabled by default:
+Every plugin execution is sandboxed:
 
-```bash
-curl -X POST https://registry.example.com/api/v1/plugins/plugin-123/enable \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
+- **Fuel-based CPU limits**: Each call is given a configurable fuel budget. If the plugin exceeds its budget, the call is terminated.
+- **Memory cap**: Configurable per plugin (default 16 MB). The WASM module cannot allocate beyond this limit.
+- **Execution timeout**: Configurable per plugin (default 10 seconds). Long-running calls are killed.
+- **No filesystem access**: Plugins cannot read or write the host filesystem.
+- **No network access**: Plugins cannot make outbound network connections.
+- **Isolation**: Each plugin runs in its own WASM instance with no shared state between plugins.
 
-### 3. Configuration
+## WIT interface reference
 
-Configure plugin settings:
+The plugin contract is defined in `wit/format-plugin.wit`. There are two worlds: `format-plugin` (v1, core functions only) and `format-plugin-v2` (adds HTTP request handling for native client protocols).
 
-```bash
-curl -X PUT https://registry.example.com/api/v1/plugins/plugin-123/config \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "max_file_size_mb": 500,
-    "allowed_extensions": [".nupkg", ".snupkg"],
-    "index_metadata": true
-  }'
-```
+### Core handler interface
 
-### 4. Disabling
+```wit
+package artifact-keeper:format@1.0.0;
 
-Temporarily disable without uninstalling:
-
-```bash
-curl -X POST https://registry.example.com/api/v1/plugins/plugin-123/disable \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
-
-### 5. Updating
-
-Update to a new version:
-
-```bash
-curl -X PUT https://registry.example.com/api/v1/plugins/plugin-123 \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -F "file=@my-plugin-v2.zip"
-```
-
-### 6. Uninstalling
-
-Remove plugin completely:
-
-```bash
-curl -X DELETE https://registry.example.com/api/v1/plugins/plugin-123 \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
-
-## Plugin Types
-
-### Format Handler Plugins
-
-Add support for new package formats:
-
-```rust
-// plugin.wit
-interface format-handler {
-  // Parse artifact metadata
-  parse-metadata: func(data: list<u8>) -> result<metadata, error>
-
-  // Validate artifact structure
-  validate: func(data: list<u8>) -> result<validation-result, error>
-
-  // Extract dependencies
-  extract-dependencies: func(data: list<u8>) -> result<list<dependency>, error>
-
-  // Generate index data
-  index: func(data: list<u8>) -> result<index-data, error>
-}
-
-record metadata {
-  name: string,
-  version: string,
-  description: option<string>,
-  authors: list<string>,
-  license: option<string>,
-  keywords: list<string>,
-}
-
-record dependency {
-  name: string,
-  version-requirement: string,
-  optional: bool,
-}
-```
-
-Example: Conan package handler
-
-```rust
-use artifact_keeper_plugin::*;
-
-#[plugin_export]
-fn parse_metadata(data: &[u8]) -> Result<Metadata, Error> {
-    let conanfile = parse_conanfile(data)?;
-
-    Ok(Metadata {
-        name: conanfile.name,
-        version: conanfile.version,
-        description: Some(conanfile.description),
-        authors: vec![conanfile.author],
-        license: Some(conanfile.license),
-        keywords: conanfile.topics,
-    })
-}
-
-#[plugin_export]
-fn validate(data: &[u8]) -> Result<ValidationResult, Error> {
-    // Validate conanfile.py structure
-    // Check for required fields
-    // Verify package contents
-}
-```
-
-### Metadata Extractor Plugins
-
-Extract custom metadata for indexing:
-
-```rust
-interface metadata-extractor {
-  extract: func(artifact-id: string, data: list<u8>) -> result<key-value-pairs, error>
-}
-
-type key-value-pairs = list<tuple<string, string>>
-```
-
-Example: Extract ML model metadata
-
-```rust
-#[plugin_export]
-fn extract(artifact_id: &str, data: &[u8]) -> Result<Vec<(String, String)>, Error> {
-    let model = load_model(data)?;
-
-    Ok(vec![
-        ("model_type".into(), model.architecture.clone()),
-        ("framework".into(), "pytorch".into()),
-        ("input_shape".into(), format!("{:?}", model.input_shape)),
-        ("parameters".into(), model.num_parameters.to_string()),
-    ])
-}
-```
-
-### Validation Hook Plugins
-
-Implement custom validation logic:
-
-```rust
-interface validation-hook {
-  // Called before artifact is accepted
-  validate-upload: func(
-    artifact: artifact-info,
-    data: list<u8>
-  ) -> result<validation-result, error>
-}
-
-record artifact-info {
-  name: string,
-  version: string,
-  format: string,
-  size-bytes: u64,
-  uploader: string,
-}
-
-record validation-result {
-  allowed: bool,
-  message: option<string>,
-  warnings: list<string>,
-}
-```
-
-Example: Size and naming policy
-
-```rust
-#[plugin_export]
-fn validate_upload(artifact: ArtifactInfo, data: &[u8]) -> Result<ValidationResult, Error> {
-    let mut warnings = Vec::new();
-
-    // Check size limit
-    if artifact.size_bytes > 1_000_000_000 {
-        return Ok(ValidationResult {
-            allowed: false,
-            message: Some("Artifact exceeds 1GB limit".into()),
-            warnings,
-        });
+interface handler {
+    record metadata {
+        path: string,
+        version: option<string>,
+        content-type: string,
+        size-bytes: u64,
+        checksum-sha256: option<string>,
     }
 
-    // Check naming convention
-    if !artifact.name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
-        warnings.push("Artifact name contains non-standard characters".into());
+    record validation-error {
+        message: string,
+        field: option<string>,
     }
 
-    Ok(ValidationResult {
-        allowed: true,
-        message: None,
-        warnings,
-    })
+    /// Returns the format key this handler supports.
+    format-key: func() -> string;
+
+    /// Parse metadata from artifact content.
+    parse-metadata: func(path: string, data: list<u8>) -> result<metadata, string>;
+
+    /// Validate artifact before storage.
+    validate: func(path: string, data: list<u8>) -> result<_, string>;
+
+    /// Generate index files for repository.
+    generate-index: func(artifacts: list<metadata>) -> result<option<list<tuple<string, list<u8>>>>, string>;
+}
+
+world format-plugin {
+    export handler;
 }
 ```
 
-### Post-Processing Plugins
+### Request handler interface (v2)
 
-Transform artifacts after upload:
+Plugins that implement the v2 world can also serve HTTP responses directly to native clients. This is how you support protocol-specific endpoints (PEP 503 simple API for pip, repodata XML for dnf, etc.).
 
-```rust
-interface post-processor {
-  process: func(
-    artifact-id: string,
-    data: list<u8>
-  ) -> result<processed-data, error>
-}
+```wit
+interface request-handler {
+    use handler.{metadata};
 
-record processed-data {
-  data: list<u8>,
-  modified: bool,
-  metadata: key-value-pairs,
-}
-```
-
-Example: Virus scanning integration
-
-```rust
-#[plugin_export]
-fn process(artifact_id: &str, data: &[u8]) -> Result<ProcessedData, Error> {
-    // Scan with ClamAV or similar
-    let scan_result = scan_for_viruses(data)?;
-
-    if scan_result.threats_found > 0 {
-        return Err(Error::SecurityThreat(scan_result.description));
+    record http-request {
+        method: string,
+        path: string,
+        query: string,
+        headers: list<tuple<string, string>>,
+        body: list<u8>,
     }
 
-    Ok(ProcessedData {
-        data: data.to_vec(),
-        modified: false,
-        metadata: vec![
-            ("scanned_at".into(), Utc::now().to_string()),
-            ("scanner_version".into(), scan_result.version),
-        ],
-    })
+    record repo-context {
+        repo-key: string,
+        base-url: string,
+        download-base-url: string,
+    }
+
+    record http-response {
+        status: u16,
+        headers: list<tuple<string, string>>,
+        body: list<u8>,
+    }
+
+    handle-request: func(
+        request: http-request,
+        context: repo-context,
+        artifacts: list<metadata>,
+    ) -> result<http-response, string>;
+}
+
+world format-plugin-v2 {
+    export handler;
+    export request-handler;
 }
 ```
 
-## Developing Plugins
+## Plugin manifest
+
+Every plugin includes a `plugin.toml` file that describes the plugin and its resource limits.
+
+```toml
+[plugin]
+name = "unity-format"
+version = "0.1.0"
+description = "Format handler for Unity .unitypackage files (gzipped tarballs)"
+author = "Artifact Keeper Team"
+license = "MIT"
+homepage = "https://github.com/artifact-keeper/artifact-keeper-example-plugin"
+min_keeper_version = "1.0.0"
+
+[format]
+key = "unity"
+display_name = "Unity Package"
+extensions = [".unitypackage"]
+content_types = ["application/gzip", "application/x-gzip"]
+
+[capabilities]
+parse_metadata = true
+validate_artifact = true
+generate_index = true
+# handle_request = true  # Add this for v2 plugins that serve native protocols
+
+[resources]
+max_memory_bytes = 16777216   # 16 MB
+max_fuel = 100000000          # 100M cycles
+max_execution_ms = 10000      # 10 seconds
+```
+
+### Manifest fields
+
+| Section | Field | Description |
+|---------|-------|-------------|
+| `[plugin]` | `name` | Unique plugin identifier |
+| | `version` | Semver version string |
+| | `description` | Short description of what the plugin does |
+| | `author` | Author name and optional email |
+| | `license` | SPDX license identifier |
+| | `homepage` | URL to the plugin's repository or documentation |
+| | `min_keeper_version` | Minimum Artifact Keeper version required |
+| `[format]` | `key` | Format identifier (must match what `format-key()` returns) |
+| | `display_name` | Human-readable name for the UI |
+| | `extensions` | File extensions this format handles |
+| | `content_types` | MIME types this format handles |
+| `[capabilities]` | `parse_metadata` | Whether the plugin implements `parse-metadata` |
+| | `validate_artifact` | Whether the plugin implements `validate` |
+| | `generate_index` | Whether the plugin implements `generate-index` |
+| | `handle_request` | Whether the plugin implements `handle-request` (v2 only) |
+| `[resources]` | `max_memory_bytes` | Maximum WASM memory allocation |
+| | `max_fuel` | Maximum CPU fuel per call |
+| | `max_execution_ms` | Maximum wall-clock time per call |
+
+## Developing a plugin
 
 ### Prerequisites
 
@@ -318,112 +180,145 @@ fn process(artifact_id: &str, data: &[u8]) -> Result<ProcessedData, Error> {
 # Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
-# Add WASM target
-rustup target add wasm32-wasi
+# Add the WASM target
+rustup target add wasm32-wasip1
 
 # Install wit-bindgen
 cargo install wit-bindgen-cli
 ```
 
-### Project Structure
+### Project structure
+
+The recommended approach is to fork the [example plugin repository](https://github.com/artifact-keeper/artifact-keeper-example-plugin), which is a Cargo workspace containing three example plugins:
 
 ```text
-my-plugin/
-├── Cargo.toml
-├── plugin.wit           # Interface definition
-├── src/
-│   └── lib.rs          # Plugin implementation
-└── plugin.toml         # Plugin manifest
+artifact-keeper-example-plugin/
+├── Cargo.toml                    # Workspace root
+├── wit/
+│   └── format-plugin.wit         # WIT contract (shared by all plugins)
+├── plugins/
+│   ├── unity-format/             # v1 plugin: .unitypackage files
+│   │   ├── Cargo.toml
+│   │   ├── plugin.toml
+│   │   └── src/lib.rs
+│   ├── pypi-format/              # v2 plugin: Python wheels with PEP 503 serving
+│   │   ├── Cargo.toml
+│   │   ├── plugin.toml
+│   │   └── src/lib.rs
+│   └── rpm-format/               # v2 plugin: RPM packages with repodata serving
+│       ├── Cargo.toml
+│       ├── plugin.toml
+│       └── src/lib.rs
 ```
 
-### Plugin Manifest (plugin.toml)
+The default build target is `wasm32-wasip1` (configured in `.cargo/config.toml`), so `cargo build --release` produces WASM binaries directly.
 
-```toml
-[plugin]
-name = "format-handler-conan"
-version = "1.0.0"
-description = "Conan package format support"
-author = "Your Name <you@example.com>"
-license = "MIT"
-
-[plugin.capabilities]
-format_handler = true
-extensions = [".conan"]
-
-[plugin.config]
-# Default configuration
-max_file_size_mb = 100
-validate_recipes = true
-```
-
-### Build Plugin
+### Build
 
 ```bash
-# Build WASM module
-cargo build --target wasm32-wasi --release
+cd artifact-keeper-example-plugin
 
-# Package plugin
-zip my-plugin.zip \
-  target/wasm32-wasi/release/my_plugin.wasm \
-  plugin.toml \
-  plugin.wit \
-  README.md
+# Build all plugins (outputs to target/wasm32-wasip1/release/*.wasm)
+cargo build --release
+
+# Run tests on the host (not in WASM)
+cargo test --target $(rustc -vV | grep host | awk '{print $2}')
 ```
 
-### Testing Plugins Locally
+### Package for installation
 
 ```bash
-# Test with artifact-keeper CLI
-artifact-keeper plugin test \
-  --plugin my-plugin.zip \
-  --artifact test-package.conan
+# ZIP a plugin for upload
+cd plugins/unity-format
+zip unity-format.zip \
+  ../../target/wasm32-wasip1/release/unity_format_plugin.wasm \
+  plugin.toml
 ```
 
-## Plugin Management API
+## Installation
 
-### List Plugins
+Plugins can be installed from two sources: ZIP file upload and Git repositories.
+
+### ZIP upload
+
+```bash
+curl -X POST https://registry.example.com/api/v1/plugins \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -F "file=@unity-format.zip"
+```
+
+### Git repository
+
+```bash
+curl -X POST https://registry.example.com/api/v1/plugins \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source": "git",
+    "repository": "https://github.com/artifact-keeper/artifact-keeper-example-plugin.git",
+    "ref": "v1.0.0"
+  }'
+```
+
+## Management
+
+### Enable a plugin
+
+Installed plugins are disabled by default. Enable to activate:
+
+```bash
+curl -X POST https://registry.example.com/api/v1/plugins/{id}/enable \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+### Disable a plugin
+
+Temporarily disable without uninstalling:
+
+```bash
+curl -X POST https://registry.example.com/api/v1/plugins/{id}/disable \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+### Configure a plugin
+
+```bash
+curl -X PUT https://registry.example.com/api/v1/plugins/{id}/config \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "max_file_size_mb": 500,
+    "index_metadata": true
+  }'
+```
+
+### Update a plugin
+
+Upload a new version:
+
+```bash
+curl -X PUT https://registry.example.com/api/v1/plugins/{id} \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -F "file=@my-plugin-v2.zip"
+```
+
+### Uninstall a plugin
+
+```bash
+curl -X DELETE https://registry.example.com/api/v1/plugins/{id} \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+### List plugins
 
 ```bash
 curl https://registry.example.com/api/v1/plugins \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-Response:
-
-```json
-{
-  "plugins": [
-    {
-      "id": "plugin-123",
-      "name": "format-handler-conan",
-      "version": "1.0.0",
-      "enabled": true,
-      "capabilities": ["format_handler"],
-      "config": {
-        "max_file_size_mb": 100
-      }
-    }
-  ]
-}
-```
-
-### Get Plugin Details
-
-```bash
-curl https://registry.example.com/api/v1/plugins/plugin-123 \
-  -H "Authorization: Bearer $TOKEN"
-```
-
-### Plugin Logs
-
-```bash
-curl https://registry.example.com/api/v1/plugins/plugin-123/logs \
-  -H "Authorization: Bearer $TOKEN"
-```
-
 ## Configuration
 
-### System-Wide Settings
+### System-wide settings
 
 ```bash
 # Enable plugin system
@@ -432,99 +327,62 @@ PLUGINS_ENABLED=true
 # Plugin storage path
 PLUGINS_PATH=/var/lib/artifact-keeper/plugins
 
-# Resource limits per plugin
+# Default resource limits (can be overridden per plugin in plugin.toml)
 PLUGIN_MAX_MEMORY_MB=256
 PLUGIN_MAX_CPU_MS=5000
 PLUGIN_MAX_EXECUTION_TIME_MS=30000
-
-# Allow network access for plugins
-PLUGIN_ALLOW_NETWORK=false
 ```
-
-### Plugin Security
-
-```bash
-# Require signature verification
-PLUGIN_REQUIRE_SIGNATURE=true
-PLUGIN_TRUSTED_KEYS=/etc/artifact-keeper/trusted-keys/
-
-# Restrict plugin sources
-PLUGIN_ALLOWED_SOURCES=https://plugins.artifact-keeper.io
-```
-
-## Best Practices
-
-### Performance
-
-- Keep plugin logic lightweight
-- Cache expensive computations
-- Stream large files instead of loading into memory
-- Use async operations where possible
-
-### Error Handling
-
-- Return meaningful error messages
-- Don't crash on invalid input
-- Validate inputs thoroughly
-- Log errors for debugging
-
-### Security
-
-- Never trust input data
-- Validate all external data
-- Use safe parsing libraries
-- Limit resource consumption
 
 ## Troubleshooting
 
-### Plugin Won't Load
+### Plugin won't load
 
-Check plugin logs:
-
-```bash
-curl https://registry.example.com/api/v1/plugins/plugin-123/logs
-```
-
-Verify WASM module:
+Check that the WASM module is valid:
 
 ```bash
-wasm-validate target/wasm32-wasi/release/my_plugin.wasm
+wasm-validate target/wasm32-wasip1/release/my_plugin.wasm
 ```
 
-### Plugin Crashes
+Verify the `format-key()` return value matches `format.key` in your `plugin.toml`.
 
-Review resource limits:
+### Plugin crashes or times out
+
+Increase resource limits in `plugin.toml`:
+
+```toml
+[resources]
+max_memory_bytes = 33554432   # 32 MB
+max_fuel = 200000000          # 200M cycles
+max_execution_ms = 30000      # 30 seconds
+```
+
+Enable debug logging on the server:
 
 ```bash
-PLUGIN_MAX_MEMORY_MB=512
-PLUGIN_MAX_EXECUTION_TIME_MS=60000
+RUST_LOG=artifact_keeper::services::wasm_plugin=debug
 ```
 
-Enable debug logging:
+## Example plugins
 
-```bash
-PLUGIN_LOG_LEVEL=debug
-```
+The [artifact-keeper-example-plugin](https://github.com/artifact-keeper/artifact-keeper-example-plugin) repository contains three working examples:
 
-### Performance Issues
+| Plugin | Format | World | Description |
+|--------|--------|-------|-------------|
+| `unity-format` | `.unitypackage` | v1 | Parses gzipped tarballs, extracts Unity asset metadata |
+| `pypi-format` | `.whl`, `.tar.gz` | v2 | Python package handling with PEP 503 simple API serving |
+| `rpm-format` | `.rpm` | v2 | RPM package handling with repodata XML serving |
 
-Profile plugin execution:
+Fork this repo to start building your own format handler plugin.
 
-```bash
-artifact-keeper plugin profile \
-  --plugin plugin-123 \
-  --artifact test-data.bin
-```
+## Roadmap
 
-## Community Plugins
+The plugin system currently supports format handlers only. The following plugin types are planned for future releases but are **not yet implemented**:
 
-Browse available plugins at: https://plugins.artifact-keeper.io
+- **Validation hook plugins**: Custom upload validation logic (size limits, naming policies, license checks)
+- **Metadata extractor plugins**: Extract custom key-value metadata from artifacts for search indexing
+- **Post-processing plugins**: Transform artifacts after upload (compression, virus scanning, signature verification)
+- **Storage backend plugins**: Custom storage backends beyond S3 and filesystem
+- **Plugin CLI testing**: A `plugin test` command for local testing without a running server
+- **Web UI installation**: Making the Install Plugin dialog in the web UI functional (it currently shows a placeholder)
 
-Popular plugins:
-
-- **format-handler-conan**: Conan C++ package support
-- **format-handler-conda**: Conda package support
-- **scanner-trivy**: Trivy security scanning integration
-- **metadata-sbom**: SBOM generation (SPDX, CycloneDX)
-- **transform-compress**: Automatic compression/decompression
-- **validator-license**: License compliance checking
+These are tracked as issues in the project backlog.

--- a/src/content/docs/docs/getting-started/architecture.mdx
+++ b/src/content/docs/docs/getting-started/architecture.mdx
@@ -245,7 +245,7 @@ flowchart LR
 ```
 
 - **WIT interface** — Plugins implement a `FormatHandler` contract defined in WebAssembly Interface Types
-- **Capabilities** — `parse_metadata`, `validate_artifact`, `generate_index` (each optional)
+- **Capabilities** — `format_key`, `parse_metadata`, `validate`, `generate_index`, plus `handle_request` for v2 plugins that serve native client protocols
 - **Lifecycle** — Install, enable, disable, reload — all without restarting the server
 - **Sandboxing** — Fuel-based CPU metering, memory limits, and execution timeouts via Wasmtime
 


### PR DESCRIPTION
## Summary

- Rewrite the WASM Plugin System page to honestly document what's implemented today (format handler plugins only)
- Remove fake plugin types (metadata extractor, validation hook, post-processing), fake community plugins, fake registry URL, fake CLI commands, and wrong WIT examples
- Add the real WIT interface (v1 and v2 worlds) from the source
- Document the actual plugin.toml manifest format with `[format]` section
- Add a Roadmap section listing planned-but-unimplemented plugin types
- Fix architecture page to list all actual WIT functions including v2 handle-request

## Test plan

- [x] Site builds without errors (`npm run build`)
- [ ] Visual review of the rewritten plugin page
- [ ] Grep confirms no remaining false claims about non-existent plugin types or registry