### PR TITLE
Document Azure RBAC authentication for Blob Storage

### DIFF
--- a/src/content/docs/docs/advanced/storage.mdx
+++ b/src/content/docs/docs/advanced/storage.mdx
@@ -305,9 +305,11 @@ All downloads will stream through the backend with `X-Artifact-Storage: proxy`.
 
 ### Azure Blob Storage
 
-Use Azure Blob Storage for Azure-native deployments.
+Use Azure Blob Storage for Azure-native deployments. Two authentication modes are supported: **Shared Key** (access key) and **Azure RBAC** (service principal or managed identity).
 
-#### Configuration
+#### Shared Key Authentication
+
+The simplest setup. Uses the storage account access key to sign requests. Supports SAS URL redirect downloads.
 
 ```bash
 STORAGE_BACKEND=azure
@@ -316,18 +318,55 @@ AZURE_STORAGE_CONTAINER=artifacts
 AZURE_STORAGE_ACCESS_KEY=base64-encoded-account-key
 ```
 
+#### Azure RBAC Authentication
+
+The recommended approach for production Azure workloads. Uses OAuth2 bearer tokens instead of access keys. The identity must have the **Storage Blob Data Contributor** role assigned on the storage account.
+
+**Service Principal** (for non-Azure environments or CI/CD):
+
+```bash
+STORAGE_BACKEND=azure
+AZURE_STORAGE_ACCOUNT=myaccount
+AZURE_STORAGE_CONTAINER=artifacts
+AZURE_TENANT_ID=your-tenant-id
+AZURE_CLIENT_ID=your-client-id
+AZURE_CLIENT_SECRET=your-client-secret
+```
+
+**Managed Identity** (for workloads on Azure VMs, AKS, App Service):
+
+```bash
+STORAGE_BACKEND=azure
+AZURE_STORAGE_ACCOUNT=myaccount
+AZURE_STORAGE_CONTAINER=artifacts
+# No credentials needed. Tokens are acquired from the Azure Instance Metadata Service (IMDS).
+# For user-assigned managed identity, set AZURE_CLIENT_ID:
+# AZURE_CLIENT_ID=your-managed-identity-client-id
+```
+
+The auth mode is selected automatically: if `AZURE_STORAGE_ACCESS_KEY` is set, Shared Key is used. Otherwise, the backend tries service principal credentials, then falls back to managed identity.
+
+#### Assigning the Storage Blob Data Contributor Role
+
+```bash
+az role assignment create \
+  --assignee <client-id-or-principal-id> \
+  --role "Storage Blob Data Contributor" \
+  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Storage/storageAccounts/<account>
+```
+
 #### Optional Settings
 
 ```bash
 AZURE_STORAGE_ENDPOINT=https://custom.endpoint.com   # Azure Government/China clouds
-AZURE_REDIRECT_DOWNLOADS=true                        # Enable SAS URL redirects
+AZURE_REDIRECT_DOWNLOADS=true                        # Enable SAS URL redirects (Shared Key only)
 AZURE_SAS_EXPIRY=3600                               # SAS token lifetime in seconds (default: 1 hour)
 STORAGE_PATH_FORMAT=native                           # native, artifactory, or migration
 ```
 
 #### Direct Downloads with SAS URLs
 
-When `AZURE_REDIRECT_DOWNLOADS=true`, artifact downloads redirect to a Shared Access Signature (SAS) URL:
+When `AZURE_REDIRECT_DOWNLOADS=true` and Shared Key auth is configured, artifact downloads redirect to a Shared Access Signature (SAS) URL:
 
 ```http
 HTTP/1.1 302 Found
@@ -336,6 +375,8 @@ X-Artifact-Storage: redirect-azure
 ```
 
 SAS tokens are read-only and expire after `AZURE_SAS_EXPIRY` seconds.
+
+SAS URL generation requires Shared Key authentication. When using Azure RBAC, redirect downloads are automatically disabled and artifacts are proxied through the backend instead.
 
 ### Google Cloud Storage (GCS)
 

--- a/src/content/docs/docs/reference/environment.mdx
+++ b/src/content/docs/docs/reference/environment.mdx
@@ -150,13 +150,18 @@ When `STORAGE_BACKEND=gcs`. Read by the **backend** process.
 
 When `STORAGE_BACKEND=azure`. Read by the **backend** process.
 
+Two authentication modes are supported. If `AZURE_STORAGE_ACCESS_KEY` is set, the backend uses **Shared Key** authentication (HMAC-signed requests). If omitted, it falls back to **Azure RBAC** using OAuth2 bearer tokens from a service principal or managed identity. The identity must have the `Storage Blob Data Contributor` role on the storage account.
+
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `AZURE_STORAGE_ACCOUNT` | Yes | - | Azure storage account name |
 | `AZURE_STORAGE_CONTAINER` | Yes | - | Blob container name |
-| `AZURE_STORAGE_ACCESS_KEY` | Yes | - | Storage account access key |
-| `AZURE_STORAGE_ENDPOINT` | No | - | Custom endpoint URL (for Azure Stack or emulators) |
-| `AZURE_REDIRECT_DOWNLOADS` | No | `false` | Redirect downloads to SAS URLs instead of proxying |
+| `AZURE_STORAGE_ACCESS_KEY` | No | - | Storage account access key. When set, uses Shared Key auth. When omitted, uses Azure RBAC. |
+| `AZURE_TENANT_ID` | RBAC (SP) | - | Azure AD tenant ID (for service principal auth) |
+| `AZURE_CLIENT_ID` | RBAC (SP) | - | Application (client) ID. Also used for user-assigned managed identity. |
+| `AZURE_CLIENT_SECRET` | RBAC (SP) | - | Service principal client secret |
+| `AZURE_STORAGE_ENDPOINT` | No | - | Custom endpoint URL (for Azure Government, China, or emulators) |
+| `AZURE_REDIRECT_DOWNLOADS` | No | `false` | Redirect downloads to SAS URLs instead of proxying. Requires Shared Key auth. |
 | `AZURE_SAS_EXPIRY` | No | `3600` | SAS URL expiry in seconds |
 
 ## Backup


### PR DESCRIPTION
## Summary

- Update environment variables reference to document RBAC auth mode (service principal and managed identity env vars)
- Update storage advanced guide with RBAC configuration examples, role assignment instructions, and auth mode auto-detection behavior
- Note SAS redirect download limitation when using RBAC

Companion to artifact-keeper/artifact-keeper#312