### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Site Bug Report
+description: Report a rendering, build, or functional issue with the documentation site
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for reporting issues with the site itself (broken rendering, build failures, navigation bugs, search issues). For content issues (typos, incorrect info, missing docs), please use the Documentation Issue template instead.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL
+      placeholder: "https://artifactkeeper.com/docs/..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - Browser:
+        - Browser Version:
+        - Operating System:
+    validations:
+      required: false
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate
+          required: true
+        - label: This is a site rendering or functional issue, not a content issue
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Backend / API Issues
+    url: https://github.com/artifact-keeper/artifact-keeper/issues/new
+    about: Report bugs or request features for the backend API and server
+  - name: Web UI Issues
+    url: https://github.com/artifact-keeper/artifact-keeper-web/issues/new
+    about: Report bugs or request features for the web frontend
+  - name: Security Vulnerability
+    url: https://github.com/artifact-keeper/artifact-keeper/security/advisories/new
+    about: Please report security vulnerabilities privately through GitHub Security Advisories
+  - name: GitHub Discussions
+    url: https://github.com/orgs/artifact-keeper/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,65 @@
+name: Documentation Issue
+description: Report an issue with the documentation or suggest improvements
+labels: ["documentation", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a documentation issue.
+
+        This repository covers the documentation at [artifactkeeper.com](https://artifactkeeper.com). For backend or API bugs, please file an issue in [artifact-keeper](https://github.com/artifact-keeper/artifact-keeper/issues/new). For web UI bugs, file in [artifact-keeper-web](https://github.com/artifact-keeper/artifact-keeper-web/issues/new). If you're unsure where the issue belongs, file it here and we'll move it if needed.
+
+  - type: dropdown
+    id: documentation-type
+    attributes:
+      label: Documentation Type
+      options:
+        - Missing documentation
+        - Incorrect or outdated information
+        - Unclear or confusing content
+        - Typo or formatting issue
+        - Missing examples
+        - Missing guide for a package format
+        - API reference issue
+        - Broken link
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: page-url
+    attributes:
+      label: Page URL or Path
+      placeholder: "e.g., https://artifactkeeper.com/docs/guides/docker or src/content/docs/guides/docker.mdx"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested-improvement
+    attributes:
+      label: Suggested Improvement
+      placeholder: "How could this documentation be improved? If you have specific wording, include it here."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Documentation Request
+description: Request a new guide, tutorial, or documentation page
+labels: ["enhancement", "documentation", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping us improve the docs.
+
+        If you're requesting support for a new package format (not just its documentation), please file that in the [backend repo](https://github.com/artifact-keeper/artifact-keeper/issues/new) instead.
+
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Request Type
+      options:
+        - New guide or tutorial
+        - New package format guide
+        - API reference
+        - Deployment guide
+        - Troubleshooting guide
+        - Architecture documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: "What documentation would you like to see?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      placeholder: "Who would benefit from this documentation and why?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      placeholder: "Links to related docs, blog posts, or examples that could help us write this"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched existing issues to make sure this is not a duplicate
+          required: true
+        - label: I have checked the existing docs to confirm this doesn't already exist
+          required: true


### PR DESCRIPTION
## Summary

- Add three GitHub issue form templates: Documentation Issue, Documentation Request, and Site Bug Report
- Add config.yml with contact links pointing to the backend, web UI, security advisories, and GitHub Discussions
- Documentation Issue is the primary template, covering content problems (typos, outdated info, missing docs, broken links)
- Documentation Request covers requests for new guides, tutorials, and documentation pages
- Site Bug Report covers rendering, build, and functional issues with the site itself (not content)
- Blank issues remain enabled for anything that doesn't fit the templates

## Test plan

- [ ] Visit https://github.com/artifact-keeper/artifact-keeper-site/issues/new/choose and verify all three templates appear
- [ ] Verify the four contact links appear at the bottom of the template chooser
- [ ] Open each template form and confirm all fields render correctly, required fields are enforced, and dropdowns populate
- [ ] Verify blank issue option is still available
- [ ] Submit a test issue with the Documentation Issue template to confirm it applies the correct labels