### PR TITLE
docs: add Windows Server deployment guide and troubleshooting

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -115,6 +115,8 @@ export default defineConfig({
           items: [
             { label: 'Kubernetes (Helm)', slug: 'docs/deployment/helm' },
             { label: 'Docker Compose', slug: 'docs/deployment/docker' },
+            { label: 'Windows Server', slug: 'docs/deployment/windows' },
+            { label: 'Windows Troubleshooting', slug: 'docs/deployment/windows-troubleshooting' },
             { label: 'Reverse Proxy & TLS', slug: 'docs/deployment/reverse-proxy' },
             { label: 'AWS', slug: 'docs/deployment/aws' },
           ],

--- a/src/content/docs/docs/deployment/windows-troubleshooting.mdx
+++ b/src/content/docs/docs/deployment/windows-troubleshooting.mdx
@@ -3,6 +3,10 @@ title: "Windows Troubleshooting"
 description: "Common issues and solutions for Artifact Keeper on Windows Server"
 ---
 
+:::caution[Beta Support]
+Windows support is currently in **beta**. If you encounter an issue not listed here, please report it on [GitHub](https://github.com/artifact-keeper/artifact-keeper/issues).
+:::
+
 This page covers the most common issues when running Artifact Keeper on Windows, along with diagnostics and fixes.
 
 ## Service Fails to Start

--- a/src/content/docs/docs/deployment/windows-troubleshooting.mdx
+++ b/src/content/docs/docs/deployment/windows-troubleshooting.mdx
@@ -1,0 +1,213 @@
+---
+title: "Windows Troubleshooting"
+description: "Common issues and solutions for Artifact Keeper on Windows Server"
+---
+
+This page covers the most common issues when running Artifact Keeper on Windows, along with diagnostics and fixes.
+
+## Service Fails to Start
+
+**Symptoms:** The `ArtifactKeeper` service stops immediately after starting, or `Start-Service` returns an error.
+
+**Diagnostics:**
+
+```powershell
+# Check the Windows Event Viewer for service errors
+Get-EventLog -LogName Application -Source ArtifactKeeper -Newest 20
+
+# Verify the service configuration
+Get-Service ArtifactKeeper | Format-List *
+
+# Try running the binary directly to see error output
+& "C:\Program Files\ArtifactKeeper\artifact-keeper.exe"
+```
+
+**Common causes:**
+
+- **Missing or invalid `.env` file.** Confirm `AK_ENV_FILE` points to the correct path:
+  ```powershell
+  [System.Environment]::GetEnvironmentVariable("AK_ENV_FILE", "Machine")
+  ```
+
+- **Invalid `DATABASE_URL`.** Test the connection manually:
+  ```powershell
+  & "C:\Program Files\PostgreSQL\16\bin\psql.exe" `
+    "postgresql://registry:changeme@localhost:5432/artifact_registry" `
+    -c "SELECT 1;"
+  ```
+
+- **Port already in use.** See [Port Conflicts](#port-conflicts) below.
+
+- **Antivirus quarantined the binary.** See [Antivirus Blocks the Binary](#antivirus-blocks-the-binary) below.
+
+## Port Conflicts
+
+**Symptoms:** The service starts but immediately exits. Event Viewer shows "address already in use" or a bind error on port 8080.
+
+**Diagnostics:**
+
+```powershell
+# Find what process is using port 8080
+Get-NetTCPConnection -LocalPort 8080 | Select-Object OwningProcess, State
+
+# Identify the process by PID
+Get-Process -Id <pid> | Select-Object Name, Path
+```
+
+**Fix:** Either stop the conflicting process, or change the Artifact Keeper bind port. In your `.env` file:
+
+```ini
+BIND_ADDRESS=0.0.0.0:8081
+```
+
+Then update your firewall rule to match the new port and restart the service.
+
+## Permission Denied on Storage Path
+
+**Symptoms:** The service starts but returns 500 errors when uploading artifacts. Logs show "permission denied" or "access denied" for the storage directory.
+
+**Diagnostics:**
+
+```powershell
+# Check current permissions on the data directory
+icacls "C:\ProgramData\ArtifactKeeper"
+```
+
+**Fix:** Grant the service account full control over the data directory:
+
+```powershell
+icacls "C:\ProgramData\ArtifactKeeper" /grant "NT SERVICE\ArtifactKeeper:(OI)(CI)F"
+```
+
+If you configured the service to run as a specific user account (not LocalSystem), replace `NT SERVICE\ArtifactKeeper` with that account name.
+
+Restart the service after changing permissions:
+
+```powershell
+Restart-Service ArtifactKeeper
+```
+
+## PostgreSQL Connection Failures
+
+**Symptoms:** Service fails to start or returns database errors. Logs show "connection refused" or authentication failures.
+
+**Diagnostics:**
+
+```powershell
+# Verify PostgreSQL is running
+Get-Service postgresql*
+
+# Test TCP connectivity
+Test-NetConnection -ComputerName localhost -Port 5432
+```
+
+**Common causes and fixes:**
+
+1. **`localhost` resolves to IPv6.** PostgreSQL may only listen on IPv4 by default. Use `127.0.0.1` instead of `localhost` in your `DATABASE_URL`:
+
+   ```ini
+   DATABASE_URL=postgresql://registry:changeme@127.0.0.1:5432/artifact_registry
+   ```
+
+2. **`pg_hba.conf` rejects the connection.** Open `C:\Program Files\PostgreSQL\16\data\pg_hba.conf` and verify that a line allows the `registry` user to connect via TCP:
+
+   ```
+   # TYPE  DATABASE        USER      ADDRESS       METHOD
+   host    artifact_registry  registry  127.0.0.1/32  scram-sha-256
+   ```
+
+   Restart PostgreSQL after editing `pg_hba.conf`:
+
+   ```powershell
+   Restart-Service postgresql-x64-16
+   ```
+
+3. **PostgreSQL is configured for named pipes only.** Verify `listen_addresses` in `postgresql.conf` includes `localhost` or `*`:
+
+   ```
+   listen_addresses = 'localhost'
+   ```
+
+## Antivirus Blocks the Binary
+
+**Symptoms:** The binary disappears after download, or the service fails to start with "file not found" errors despite the file existing moments earlier.
+
+**Diagnostics:** Check your antivirus quarantine log. Windows Defender quarantine history:
+
+```powershell
+Get-MpThreatDetection | Where-Object { $_.Resources -like "*ArtifactKeeper*" }
+```
+
+**Fix:** Add exclusions for the Artifact Keeper binary and data directory:
+
+```powershell
+# Windows Defender exclusions
+Add-MpPreference -ExclusionPath "C:\Program Files\ArtifactKeeper"
+Add-MpPreference -ExclusionPath "C:\ProgramData\ArtifactKeeper"
+```
+
+For third-party antivirus software, consult your vendor's documentation on adding path and process exclusions. Exclude both the installation directory and the storage directory.
+
+## Logs Not Appearing
+
+**Symptoms:** You expect log output but find nothing in the log directory or Event Viewer.
+
+**Diagnostics:**
+
+```powershell
+# Check the RUST_LOG setting in your .env
+Select-String -Path "C:\ProgramData\ArtifactKeeper\config\.env" -Pattern "RUST_LOG"
+
+# Check Event Viewer application logs
+Get-EventLog -LogName Application -Source ArtifactKeeper -Newest 10
+```
+
+**Fix:**
+
+1. Verify `RUST_LOG` is set in your `.env` file. A missing value means no log output:
+
+   ```ini
+   RUST_LOG=info
+   ```
+
+2. Confirm the log directory is writable by the service account:
+
+   ```powershell
+   icacls "C:\ProgramData\ArtifactKeeper\logs"
+   ```
+
+3. When running manually (not as a service), logs go to stdout. When running as a service, logs are written to the Windows Event Log and to the log directory. If neither has output, the binary may not be starting at all. Run it directly from a terminal to see error output.
+
+## Upgrade Fails
+
+**Symptoms:** After replacing the binary, the service fails to start. Event Viewer shows database migration errors.
+
+**Diagnostics:**
+
+```powershell
+# Check Event Viewer for migration errors
+Get-EventLog -LogName Application -Source ArtifactKeeper -Newest 20
+
+# Try running the binary directly to see the full error
+& "C:\Program Files\ArtifactKeeper\artifact-keeper.exe"
+```
+
+**Fix:**
+
+1. **Restore the database** from your pre-upgrade backup:
+
+   ```powershell
+   & "C:\Program Files\PostgreSQL\16\bin\psql.exe" `
+     -U registry -d artifact_registry -f backup.sql
+   ```
+
+2. **Restore the previous binary.** Copy the old `artifact-keeper.exe` back and restart the service.
+
+3. **Check the release notes** for the version you are upgrading to. Some releases require intermediate upgrades (for example, upgrading from v1.0 to v1.3 may require upgrading to v1.2 first).
+
+4. If migration errors persist after restoring, check that the database user has `CREATE` and `ALTER` privileges on the database. Migrations need schema modification rights:
+
+   ```powershell
+   & "C:\Program Files\PostgreSQL\16\bin\psql.exe" -U postgres -c `
+     "GRANT ALL PRIVILEGES ON DATABASE artifact_registry TO registry;"
+   ```

--- a/src/content/docs/docs/deployment/windows.mdx
+++ b/src/content/docs/docs/deployment/windows.mdx
@@ -1,0 +1,267 @@
+---
+title: "Windows Server"
+description: "Deploy Artifact Keeper as a Windows Service with PostgreSQL on Windows Server"
+---
+
+Deploy Artifact Keeper on Windows Server 2019, 2022, or 2025 as a native Windows Service. This guide covers MSI-based installation, manual setup, PostgreSQL configuration, and production hardening.
+
+## System Requirements
+
+| Component | Minimum | Recommended |
+|-----------|---------|-------------|
+| **OS** | Windows Server 2019 or Windows 10 (evaluation only) | Windows Server 2022 or 2025 |
+| **RAM** | 4 GB | 8 GB |
+| **CPU** | 2 cores | 4+ cores |
+| **Disk** | 100 GB for artifact storage | SSD with dedicated volume |
+| **Database** | PostgreSQL 16+ (required) | |
+| **Search** | Meilisearch (optional) | Recommended for full-text search |
+
+## Install PostgreSQL
+
+Download PostgreSQL 16 from [enterprisedb.com](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads) and run the installer. Select the defaults, and note the superuser password you set during installation.
+
+For automated deployments, use a silent install:
+
+```powershell
+.\postgresql-16-windows-x64.exe --mode unattended `
+  --superpassword "YourSuperPassword" `
+  --serverport 5432 `
+  --prefix "C:\Program Files\PostgreSQL\16"
+```
+
+Create the database and user:
+
+```powershell
+& "C:\Program Files\PostgreSQL\16\bin\psql.exe" -U postgres -c @"
+CREATE DATABASE artifact_registry;
+CREATE USER registry WITH PASSWORD 'changeme';
+GRANT ALL PRIVILEGES ON DATABASE artifact_registry TO registry;
+ALTER DATABASE artifact_registry OWNER TO registry;
+"@
+```
+
+Verify that PostgreSQL is running:
+
+```powershell
+Get-Service postgresql*
+```
+
+## Install with MSI
+
+The MSI installer is the recommended path for most deployments.
+
+### 1. Download
+
+Download `ArtifactKeeper-x64.msi` from the [GitHub Releases](https://github.com/artifact-keeper/artifact-keeper/releases) page.
+
+### 2. Run the Installer
+
+The installer performs the following steps:
+
+- Installs the binary to `C:\Program Files\ArtifactKeeper\`
+- Registers the `ArtifactKeeper` Windows Service
+- Creates data directories under `C:\ProgramData\ArtifactKeeper\`
+- Prompts for database connection settings and bind address
+
+### 3. Silent Install
+
+For enterprise deployment or automation, use `msiexec` with properties:
+
+```powershell
+msiexec /i ArtifactKeeper-1.2.0-x64.msi /qn `
+  DB_HOST=localhost DB_PORT=5432 `
+  DB_NAME=artifact_registry DB_USER=registry `
+  DB_PASSWORD=changeme BIND_ADDRESS=0.0.0.0:8080
+```
+
+Skip ahead to [First-Boot Setup](#first-boot-setup) after installation completes.
+
+## Manual Installation
+
+If you prefer not to use the MSI, you can set up Artifact Keeper manually.
+
+### 1. Download the Binary
+
+Download the standalone `artifact-keeper.exe` from [GitHub Releases](https://github.com/artifact-keeper/artifact-keeper/releases).
+
+### 2. Create Directories
+
+```powershell
+New-Item -ItemType Directory -Force -Path "C:\Program Files\ArtifactKeeper"
+New-Item -ItemType Directory -Force -Path "C:\ProgramData\ArtifactKeeper\artifacts"
+New-Item -ItemType Directory -Force -Path "C:\ProgramData\ArtifactKeeper\plugins"
+New-Item -ItemType Directory -Force -Path "C:\ProgramData\ArtifactKeeper\logs"
+New-Item -ItemType Directory -Force -Path "C:\ProgramData\ArtifactKeeper\config"
+```
+
+Copy `artifact-keeper.exe` into `C:\Program Files\ArtifactKeeper\`.
+
+### 3. Create Configuration
+
+Create `C:\ProgramData\ArtifactKeeper\config\.env` with the following:
+
+```ini
+DATABASE_URL=postgresql://registry:changeme@localhost:5432/artifact_registry
+JWT_SECRET=generate-a-strong-random-secret-at-least-32-bytes
+STORAGE_PATH=C:\ProgramData\ArtifactKeeper\artifacts
+BIND_ADDRESS=0.0.0.0:8080
+RUST_LOG=info
+```
+
+Generate a strong JWT secret in PowerShell:
+
+```powershell
+[Convert]::ToBase64String((1..64 | ForEach-Object { Get-Random -Maximum 256 }) -as [byte[]])
+```
+
+### 4. Register the Windows Service
+
+```powershell
+New-Service -Name "ArtifactKeeper" `
+  -BinaryPathName '"C:\Program Files\ArtifactKeeper\artifact-keeper.exe" --service' `
+  -DisplayName "Artifact Keeper" `
+  -Description "Artifact Keeper registry server" `
+  -StartupType Automatic
+
+# Set the environment file path so the service finds its config
+[System.Environment]::SetEnvironmentVariable(
+  "AK_ENV_FILE",
+  "C:\ProgramData\ArtifactKeeper\config\.env",
+  "Machine"
+)
+
+# Configure automatic restart on failure (3 attempts, 10-second delay each)
+sc.exe failure ArtifactKeeper reset= 86400 actions= restart/10000/restart/10000/restart/10000
+```
+
+Alternatively, the binary can register itself as a service:
+
+```powershell
+& "C:\Program Files\ArtifactKeeper\artifact-keeper.exe" --install
+```
+
+## First-Boot Setup
+
+Start the service:
+
+```powershell
+Start-Service ArtifactKeeper
+```
+
+On first start, the server generates a random admin password and writes it to the storage directory:
+
+```powershell
+Get-Content "C:\ProgramData\ArtifactKeeper\artifacts\admin.password"
+```
+
+The API is locked until you change the admin password. Open `http://localhost:8080` in a browser, log in with username `admin` and the generated password, then set a new password.
+
+Verify the service is healthy:
+
+```powershell
+Invoke-RestMethod -Uri http://localhost:8080/health
+```
+
+See the [Quickstart Guide](/docs/getting-started/quickstart) for full first-boot walkthrough steps.
+
+## Firewall Configuration
+
+Open the API port for inbound connections:
+
+```powershell
+New-NetFirewallRule -DisplayName "Artifact Keeper API" `
+  -Direction Inbound -Protocol TCP -LocalPort 8080 -Action Allow
+```
+
+If you run Meilisearch on a separate host, also open port 7700. For gRPC clients, open port 9090.
+
+## Optional: Meilisearch
+
+Meilisearch provides fast full-text search for artifacts and metadata. Without it, search falls back to PostgreSQL full-text search, which works but is slower on large registries.
+
+1. Download the Windows binary from [meilisearch.com](https://www.meilisearch.com/docs/learn/getting_started/installation#local-installation).
+
+2. Run it as a service using [NSSM](https://nssm.cc/):
+
+   ```powershell
+   nssm install Meilisearch "C:\Program Files\Meilisearch\meilisearch.exe"
+   nssm set Meilisearch AppParameters "--db-path C:\ProgramData\Meilisearch\data.ms"
+   nssm start Meilisearch
+   ```
+
+3. Add the following to your Artifact Keeper `.env` file:
+
+   ```ini
+   MEILISEARCH_URL=http://localhost:7700
+   ```
+
+4. Restart the Artifact Keeper service:
+
+   ```powershell
+   Restart-Service ArtifactKeeper
+   ```
+
+## Upgrading
+
+### MSI Upgrade
+
+Download the new MSI and run the installer. Configuration and data directories are preserved. The service restarts automatically after the upgrade.
+
+### Manual Upgrade
+
+1. Back up the database:
+
+   ```powershell
+   & "C:\Program Files\PostgreSQL\16\bin\pg_dump.exe" `
+     -U registry artifact_registry > backup.sql
+   ```
+
+2. Stop the service, replace the binary, and start the service:
+
+   ```powershell
+   Stop-Service ArtifactKeeper
+   Copy-Item .\artifact-keeper.exe "C:\Program Files\ArtifactKeeper\artifact-keeper.exe" -Force
+   Start-Service ArtifactKeeper
+   ```
+
+Database migrations run automatically on startup. Check the Event Viewer for any migration errors after upgrading.
+
+## Uninstalling
+
+### MSI Uninstall
+
+Remove Artifact Keeper through **Add/Remove Programs** (Settings > Apps), or run:
+
+```powershell
+& "C:\Program Files\ArtifactKeeper\artifact-keeper.exe" --uninstall
+```
+
+### Manual Uninstall
+
+```powershell
+Stop-Service ArtifactKeeper
+sc.exe delete ArtifactKeeper
+Remove-Item "C:\Program Files\ArtifactKeeper" -Recurse -Force
+```
+
+In both cases, the data directory at `C:\ProgramData\ArtifactKeeper\` is preserved. Remove it manually if you no longer need the stored artifacts. The PostgreSQL database is also left intact; drop it manually if desired.
+
+## Production Checklist
+
+- [ ] Set a strong `JWT_SECRET` (64+ characters)
+- [ ] Admin password changed from the generated default
+- [ ] TLS configured via reverse proxy (IIS, Caddy, or another proxy)
+- [ ] Firewall rules restrict access to required ports only
+- [ ] Storage path on a volume with sufficient space and regular backups
+- [ ] Database backups scheduled (Task Scheduler + `pg_dump`)
+- [ ] Service recovery options configured (automatic restart on failure)
+- [ ] Antivirus exclusions added for the binary and storage path
+- [ ] `RUST_LOG` set to `info` or `warn` for production (not `debug`)
+- [ ] Monitoring configured (poll `/health` endpoint)
+
+## Next Steps
+
+- [Configuration Reference](/docs/getting-started/configuration) for all environment variables
+- [Reverse Proxy & TLS](/docs/deployment/reverse-proxy) for setting up HTTPS
+- [Windows Troubleshooting](/docs/deployment/windows-troubleshooting) for common issues and fixes
+- [Quickstart Guide](/docs/getting-started/quickstart) for creating your first repository

--- a/src/content/docs/docs/deployment/windows.mdx
+++ b/src/content/docs/docs/deployment/windows.mdx
@@ -3,6 +3,10 @@ title: "Windows Server"
 description: "Deploy Artifact Keeper as a Windows Service with PostgreSQL on Windows Server"
 ---
 
+:::caution[Beta Support]
+Windows support is currently in **beta**. The core functionality works, but you may encounter rough edges. If you run into issues, please report them on [GitHub](https://github.com/artifact-keeper/artifact-keeper/issues).
+:::
+
 Deploy Artifact Keeper on Windows Server 2019, 2022, or 2025 as a native Windows Service. This guide covers MSI-based installation, manual setup, PostgreSQL configuration, and production hardening.
 
 ## System Requirements

--- a/src/content/docs/docs/getting-started/installation.mdx
+++ b/src/content/docs/docs/getting-started/installation.mdx
@@ -156,9 +156,9 @@ sudo systemctl start artifact-keeper
 sudo systemctl status artifact-keeper
 ```
 
-### Windows Service
+### Windows Service (Beta)
 
-Artifact Keeper runs as a native Windows Service on Windows Server 2019, 2022, and 2025. An MSI installer handles service registration, directory creation, and configuration. A standalone binary is also available for manual setup.
+Artifact Keeper runs as a native Windows Service on Windows Server 2019, 2022, and 2025. An MSI installer handles service registration, directory creation, and configuration. A standalone binary is also available for manual setup. Windows support is currently in beta.
 
 See the full [Windows Server deployment guide](/docs/deployment/windows) for installation steps, service configuration, and production hardening.
 

--- a/src/content/docs/docs/getting-started/installation.mdx
+++ b/src/content/docs/docs/getting-started/installation.mdx
@@ -156,6 +156,12 @@ sudo systemctl start artifact-keeper
 sudo systemctl status artifact-keeper
 ```
 
+### Windows Service
+
+Artifact Keeper runs as a native Windows Service on Windows Server 2019, 2022, and 2025. An MSI installer handles service registration, directory creation, and configuration. A standalone binary is also available for manual setup.
+
+See the full [Windows Server deployment guide](/docs/deployment/windows) for installation steps, service configuration, and production hardening.
+
 ### Reverse Proxy
 
 The Docker Compose setup includes Caddy as a reverse proxy with automatic TLS. For production with a real domain:


### PR DESCRIPTION
## Summary

Adds comprehensive Windows Server deployment documentation, covering installation, service management, and troubleshooting.

New pages:

- **Windows Server** (`docs/deployment/windows`): MSI and manual install paths, PostgreSQL setup, Windows Service registration with restart-on-failure, Meilisearch integration, firewall rules, upgrade and uninstall procedures, and a production checklist.
- **Windows Troubleshooting** (`docs/deployment/windows-troubleshooting`): Seven common issues (service startup failures, port conflicts, storage permissions, PostgreSQL connection problems, antivirus interference, missing logs, upgrade failures) with symptoms, diagnostic commands, and fixes.

Also updates:

- **Installation page**: adds a "Windows Service" section with a link to the full guide.
- **Sidebar** (`astro.config.mjs`): adds both new pages under the Deployment section.

## Test Checklist
- [x] `npm run build` passes
- [x] Verified page renders correctly locally (`npm run dev`)
- [x] Links are valid (no broken links)
- [x] Images load correctly
- [x] No regressions on other pages