### PR TITLE
chore: use self-hosted runners for CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     steps:
       - uses: actions/checkout@v4
 
@@ -37,7 +37,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sonar:
     name: SonarCloud Scan
-    runs-on: ubuntu-latest
+    runs-on: ak-ci-runners
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Switch all workflow jobs from GitHub-hosted `ubuntu-latest` to the self-hosted `ak-ci-runners` scale set on the K8s cluster. Covers deploy.yml (build + deploy jobs) and sonar.yml.

## Test Checklist
- [x] `npm run build` passes
- [ ] Verified page renders correctly locally (`npm run dev`)
- [x] Links are valid (no broken links)
- [x] Images load correctly
- [x] No regressions on other pages