### PR TITLE
correct S3_PREFIX name in storage.mdx

### DIFF
--- a/src/content/docs/docs/advanced/storage.mdx
+++ b/src/content/docs/docs/advanced/storage.mdx
@@ -69,7 +69,7 @@ S3_REGION=us-east-1
 S3_ENDPOINT=https://s3.amazonaws.com  # Optional, for S3-compatible services
 S3_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 S3_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-S3_PATH_PREFIX=artifacts/  # Optional, prefix for all keys
+S3_PREFIX=artifacts/  # Optional, prefix for all keys
 ```
 
 #### AWS S3


### PR DESCRIPTION
## Summary
correct name for s3 prefix

backend/src/storage/s3.rs#L111 is where i found it. I set it incorrectly first time. After i change env variable name, it worked as expected. 


