### PR TITLE
docs: update search backend docs from Meilisearch to OpenSearch (companion to artifact-keeper#830)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -119,6 +119,7 @@ export default defineConfig({
             { label: 'Windows Troubleshooting', slug: 'docs/deployment/windows-troubleshooting' },
             { label: 'Reverse Proxy & TLS', slug: 'docs/deployment/reverse-proxy' },
             { label: 'AWS', slug: 'docs/deployment/aws' },
+            { label: 'Migrate 1.1 to 1.2 (OpenSearch)', slug: 'docs/deployment/migration-meili-to-opensearch' },
           ],
         },
         {

--- a/src/content/docs/docs/advanced/edge-nodes.mdx
+++ b/src/content/docs/docs/advanced/edge-nodes.mdx
@@ -18,7 +18,7 @@ graph TD
         P1_BE["⚙️ Backend"]
         P1_DB[("🐘 PostgreSQL")]
         P1_ST["💾 Storage"]
-        P1_MS["🔍 Meilisearch"]
+        P1_MS["🔍 OpenSearch"]
         P1_BE --> P1_DB
         P1_BE --> P1_ST
         P1_BE --> P1_MS

--- a/src/content/docs/docs/cli/tui.mdx
+++ b/src/content/docs/docs/cli/tui.mdx
@@ -41,7 +41,7 @@ Switch between panels using the number keys (`1` through `4`) or `Tab`.
 
 ## Global Search
 
-Press `s` to open the global search overlay. This uses the Meilisearch-powered `advanced_search` endpoint to search across all repositories on the selected instance.
+Press `s` to open the global search overlay. This uses the OpenSearch-powered `advanced_search` endpoint to search across all repositories on the selected instance.
 
 Search results display:
 - Artifact name

--- a/src/content/docs/docs/deployment/aws.mdx
+++ b/src/content/docs/docs/deployment/aws.mdx
@@ -33,7 +33,7 @@ graph TD
             subgraph DATA_SERVICES["Data Services"]
                 direction LR
                 PG["🐘 PostgreSQL 16\n:5432"]
-                MS["🔍 Meilisearch\n:7700"]
+                MS["🔍 OpenSearch\n:9200"]
                 TV["🛡️ Trivy\n:8090"]
             end
 
@@ -46,7 +46,7 @@ graph TD
         subgraph EBS["💾 EBS gp3 Volume · /data/"]
             direction LR
             PG_DATA["postgres/"]
-            MS_DATA["meilisearch/"]
+            MS_DATA["opensearch/"]
             STORAGE["storage/"]
             TV_CACHE["trivy-cache/"]
         end
@@ -131,9 +131,9 @@ Output:
 
 Access URL: http://<PUBLIC_IP>
 
-Database Password:  <generated>
-Meilisearch Key:    <generated>
-JWT Secret:         <generated>
+Database Password:    <generated>
+OpenSearch Password:  <generated>
+JWT Secret:           <generated>
 
 Docker Compose Dir: /opt/artifact-keeper
 

--- a/src/content/docs/docs/deployment/docker.mdx
+++ b/src/content/docs/docs/deployment/docker.mdx
@@ -55,7 +55,7 @@ The default `docker-compose.yml` runs these services:
 | **Web UI** | `ghcr.io/artifact-keeper/artifact-keeper-web` | 3000 (internal) | Next.js frontend |
 | **Caddy** | `caddy:2-alpine` | **30080** (HTTP), **30443** (HTTPS) | Reverse proxy |
 | **PostgreSQL** | `postgres:16-alpine` | 30432 | Metadata database |
-| **Meilisearch** | `getmeili/meilisearch:v1.12` | 7700 | Full-text search |
+| **OpenSearch** | `opensearchproject/opensearch:2.19.1` | 9200 | Full-text search |
 | **Trivy** | `aquasec/trivy:latest` | 8090 | Vulnerability scanning |
 
 Caddy routes:
@@ -184,7 +184,7 @@ All data is stored in Docker named volumes:
 | `postgres_data` | Database (users, repositories, metadata) |
 | `artifact_storage` | Uploaded artifacts |
 | `backup_storage` | Automated backups |
-| `meilisearch_data` | Search indexes |
+| `opensearch_data` | Search indexes |
 | `trivy_cache` | Vulnerability database cache |
 | `caddy_data` | TLS certificates |
 
@@ -221,8 +221,8 @@ curl -s http://localhost:30080/health | jq
 # Database
 docker compose exec postgres pg_isready -U registry
 
-# Meilisearch
-curl -s http://localhost:7700/health | jq
+# OpenSearch
+curl -s -u admin:admin -k https://localhost:9200/_cluster/health | jq
 ```
 
 ## Troubleshooting
@@ -256,55 +256,63 @@ docker system df -v      # Check Docker disk usage
 docker system prune -a   # Clean unused images/containers
 ```
 
-### Meilisearch CrashLoopBackOff / Database Errors
+### OpenSearch CrashLoopBackOff or Start Failures
 
-Meilisearch stores its data in a `data.ms` directory. When upgrading Meilisearch to a new major version, the database format may be incompatible with the previous version. Symptoms include:
+OpenSearch stores its data in `/usr/share/opensearch/data`. When upgrading OpenSearch across major versions, an existing index directory written by an older release may be incompatible. Symptoms include:
 
-- Container starts, shows the banner, then immediately exits
-- CrashLoopBackOff in Kubernetes with hundreds of restarts
-- Log errors mentioning database version mismatch or corruption
+- Container starts, logs a bootstrap check failure, then exits
+- CrashLoopBackOff in Kubernetes with repeated restarts
+- Log errors mentioning `vm.max_map_count`, cluster state corruption, or incompatible index metadata
 
-**Fix — Docker Compose:**
+The most common first-run failure on Linux hosts is `vm.max_map_count` being too low. Raise it on the host:
 
 ```bash
-# 1. Export your search data first (if you have important custom indexes)
-# Meilisearch indexes are rebuilt from the backend on startup, so this is usually safe to skip.
+sudo sysctl -w vm.max_map_count=262144
+```
 
-# 2. Stop Meilisearch and delete the volume
-docker compose down meilisearch
-docker volume rm artifact-keeper_meilisearch_data
+Add `vm.max_map_count=262144` to `/etc/sysctl.conf` to make it permanent.
 
-# 3. Restart — Meilisearch creates a fresh database, backend re-indexes automatically
+**Fix for data corruption, Docker Compose:**
+
+```bash
+# 1. Search indexes are derived from PostgreSQL, so deleting them is safe.
+#    The backend re-indexes automatically on startup.
+
+# 2. Stop OpenSearch and delete the volume
+docker compose down opensearch
+docker volume rm artifact-keeper_opensearch_data
+
+# 3. Restart. OpenSearch creates a fresh cluster, backend re-indexes automatically
 docker compose up -d
 ```
 
-**Fix — Kubernetes:**
+**Fix for data corruption, Kubernetes:**
 
 ```bash
-# 1. Delete the Meilisearch PVC (adjust namespace and name)
-kubectl delete pvc meilisearch-data -n <namespace>
+# 1. Delete the OpenSearch PVC (adjust namespace and name)
+kubectl delete pvc opensearch-data -n <namespace>
 
 # 2. Delete the pod to trigger recreation with a fresh volume
-kubectl delete pod -n <namespace> -l app.kubernetes.io/component=meilisearch
+kubectl delete pod -n <namespace> -l app.kubernetes.io/component=opensearch
 
-# 3. The backend re-indexes all artifacts into Meilisearch on reconnection
+# 3. The backend re-indexes all artifacts into OpenSearch on reconnection
 ```
 
-**Note:** Meilisearch search indexes are derived from PostgreSQL data. Deleting and recreating the Meilisearch volume is safe — the backend rebuilds the search index automatically. No artifact data is lost.
+**Note:** OpenSearch search indexes are derived from PostgreSQL data. Deleting and recreating the OpenSearch volume is safe. The backend rebuilds the search index automatically. No artifact data is lost.
 
-### Meilisearch High Memory Usage
+### OpenSearch High Memory Usage
 
-Meilisearch spawns one worker per CPU core by default. On large machines this can exceed memory limits. Set `MEILI_MAX_INDEXING_THREADS` to limit worker count:
+OpenSearch defaults to a 1 GB JVM heap. On small hosts this can be too much; on large hosts it may be too little to avoid frequent GC. Tune the heap via `OPENSEARCH_JAVA_OPTS`:
 
 ```yaml
 # docker-compose.yml
 services:
-  meilisearch:
+  opensearch:
     environment:
-      MEILI_MAX_INDEXING_THREADS: 4
+      OPENSEARCH_JAVA_OPTS: "-Xms2g -Xmx2g"
 ```
 
-For Kubernetes, add to the Meilisearch container environment in your Helm values or deployment spec.
+Set `-Xms` and `-Xmx` to the same value, and do not exceed 50% of host RAM. For Kubernetes, set the same env var in your Helm values or StatefulSet spec.
 
 ## Production Checklist
 

--- a/src/content/docs/docs/deployment/helm.mdx
+++ b/src/content/docs/docs/deployment/helm.mdx
@@ -9,7 +9,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 The Helm chart, Terraform modules, ArgoCD configs, and monitoring stack are provided as **getting started templates**. They should be reviewed and modified to match your specific infrastructure requirements, security policies, and operational needs before use in production.
 :::
 
-Deploy Artifact Keeper on Kubernetes using the official Helm chart. The chart includes all services: backend API, web frontend, PostgreSQL, Meilisearch, Trivy, and DependencyTrack.
+Deploy Artifact Keeper on Kubernetes using the official Helm chart. The chart includes all services: backend API, web frontend, PostgreSQL, OpenSearch, Trivy, and DependencyTrack.
 
 ## Prerequisites
 
@@ -69,7 +69,7 @@ graph TD
         WEB["Web Frontend\n(Deployment)"]
         EDGE["Edge Replication\n(Deployment)"]
         PG["PostgreSQL\n(StatefulSet)"]
-        MS["Meilisearch\n(Deployment)"]
+        MS["OpenSearch\n(StatefulSet)"]
         TV["Trivy\n(Deployment)"]
         DT["DependencyTrack\n(Deployment)"]
         HPA["HPA"]
@@ -122,6 +122,21 @@ graph TD
 | `dependencyTrack.enabled` | Enable DependencyTrack | `true` |
 | `dependencyTrack.bootstrap.enabled` | Auto-configure DependencyTrack | `true` |
 
+### Search (OpenSearch)
+
+Search is handled by a top-level `opensearch:` values block. The chart ships an in-cluster single-node OpenSearch StatefulSet by default. For external OpenSearch clusters (managed service, existing shared cluster), disable the in-cluster deployment and point the backend at the external endpoint via `backend.env`.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `opensearch.enabled` | Deploy in-cluster OpenSearch | `true` |
+| `opensearch.image.repository` | OpenSearch image | `opensearchproject/opensearch` |
+| `opensearch.image.tag` | Image tag | `2.19.1` |
+| `opensearch.persistence.size` | Storage size | `20Gi` |
+| `opensearch.auth.username` | Admin username | `admin` |
+| `opensearch.auth.existingSecret` | Use existing K8s secret for the admin password | `""` |
+
+The chart change that introduces this top-level block is landing in a companion PR to `artifact-keeper-iac`. Until that chart version is released, stick with the previous values schema.
+
 ### Ingress
 
 | Parameter | Description | Default |
@@ -149,6 +164,10 @@ For production, we recommend:
 4. **Enable monitoring** — Set `serviceMonitor.enabled: true` with kube-prometheus-stack
 5. **Enable network policies** — Set `networkPolicy.enabled: true`
 6. **Use external secrets** — Use `externalDatabase.existingSecret` for database credentials
+
+## Upgrading from Meilisearch (1.1 to 1.2)
+
+Artifact Keeper 1.2 replaces Meilisearch with OpenSearch as the search backend. If you are upgrading an existing Helm release from 1.1.x, follow the [Meilisearch to OpenSearch migration guide](/docs/deployment/migration-meili-to-opensearch) before running `helm upgrade`. The backend will re-index from PostgreSQL on first boot, so no search data needs to be migrated.
 
 ## Using Docker Hub Instead of ghcr.io
 

--- a/src/content/docs/docs/deployment/migration-meili-to-opensearch.mdx
+++ b/src/content/docs/docs/deployment/migration-meili-to-opensearch.mdx
@@ -1,0 +1,149 @@
+---
+title: "Migrating from Meilisearch to OpenSearch (1.1 to 1.2)"
+description: "Operator guide for switching the search backend from Meilisearch to OpenSearch when upgrading to Artifact Keeper 1.2"
+---
+
+Artifact Keeper 1.2 replaces Meilisearch with OpenSearch as the search backend. The change is driven by OpenSearch's richer query DSL, broader ecosystem, and existing operational familiarity for teams running Elasticsearch-style clusters.
+
+No search data needs to be migrated. The backend rebuilds its indexes from PostgreSQL on first boot, so upgrading is purely a matter of swapping the service and updating environment variables.
+
+## What changed
+
+| | 1.1.x | 1.2.x |
+|---|---|---|
+| Image | `getmeili/meilisearch:v1.12` | `opensearchproject/opensearch:2.19.1` |
+| Port | `7700` | `9200` |
+| Health check | `/health` | `/_cluster/health` |
+| Env vars | `MEILISEARCH_URL`, `MEILISEARCH_API_KEY` | `OPENSEARCH_URL`, `OPENSEARCH_USERNAME`, `OPENSEARCH_PASSWORD`, `OPENSEARCH_ALLOW_INVALID_CERTS` |
+| Auth | Single master API key | Username and password (security plugin) |
+| Health field | `meilisearch` | `opensearch` |
+
+The old `MEILISEARCH_URL` and `MEILISEARCH_API_KEY` variables are no longer read. Leaving them set has no effect; remove them during the upgrade to avoid confusion.
+
+## Migration steps
+
+### 1. Stop the Meilisearch service
+
+Stop Meilisearch before bringing up OpenSearch, so the two do not contend for ports or volumes during the switch.
+
+**Docker Compose:**
+
+```bash
+docker compose stop meilisearch
+```
+
+**Kubernetes (Helm):**
+
+```bash
+kubectl scale deployment/<release>-meilisearch --replicas=0 -n <namespace>
+```
+
+You can delete the Meilisearch volume or PVC now or later. Search indexes are derived from PostgreSQL, so nothing in Meilisearch is authoritative.
+
+### 2. Deploy OpenSearch
+
+Choose the deployment path that matches your environment:
+
+- **Docker Compose:** The updated `docker-compose.yml` in the 1.2 release ships OpenSearch 2.19.1. See the [Docker Compose deployment guide](/docs/deployment/docker) for the full service list and volume layout.
+- **Kubernetes (Helm):** The 1.2 chart introduces a top-level `opensearch:` values block. See the [Helm chart deployment guide](/docs/deployment/helm) for the available parameters.
+- **AWS EC2:** The Packer AMI and Docker Compose snippet have been updated. See the [AWS deployment guide](/docs/deployment/aws).
+- **Windows Server:** The optional OpenSearch setup is documented in the [Windows Server guide](/docs/deployment/windows).
+
+On Linux hosts, raise `vm.max_map_count` to 262144 before starting OpenSearch. This is an OpenSearch bootstrap requirement:
+
+```bash
+sudo sysctl -w vm.max_map_count=262144
+```
+
+Add the same line to `/etc/sysctl.conf` to persist it across reboots.
+
+### 3. Set the new environment variables
+
+On the backend service, remove the old Meilisearch variables and add the OpenSearch variables:
+
+```bash
+# Remove
+# MEILISEARCH_URL=...
+# MEILISEARCH_API_KEY=...
+
+# Add
+OPENSEARCH_URL=https://opensearch:9200
+OPENSEARCH_USERNAME=admin
+OPENSEARCH_PASSWORD=your-opensearch-password
+# Only for self-signed dev clusters:
+# OPENSEARCH_ALLOW_INVALID_CERTS=true
+```
+
+For production, use a proper TLS certificate on the OpenSearch node and leave `OPENSEARCH_ALLOW_INVALID_CERTS` unset. For local Docker Compose development against the default OpenSearch demo certificates, set `OPENSEARCH_ALLOW_INVALID_CERTS=true`.
+
+See the [Environment Variables reference](/docs/reference/environment#search-opensearch) for the full variable table.
+
+### 4. Restart the backend
+
+Roll the backend so it picks up the new variables:
+
+**Docker Compose:**
+
+```bash
+docker compose up -d backend
+```
+
+**Kubernetes:**
+
+```bash
+kubectl rollout restart deployment/<release>-artifact-keeper-backend -n <namespace>
+```
+
+On startup, the backend detects that OpenSearch has no indexes and auto-reindexes from PostgreSQL. For small registries, this completes in seconds. For large registries (hundreds of thousands of artifacts), expect several minutes. The backend continues to serve uploads, downloads, and API requests during the rebuild; search queries return partial results until indexing completes.
+
+Watch progress in the backend logs:
+
+```bash
+docker compose logs -f backend | grep -i opensearch
+```
+
+### 5. Verify
+
+Check the health endpoint:
+
+```bash
+curl -s http://localhost:30080/health | jq '.checks.opensearch'
+```
+
+Expected output:
+
+```json
+{
+  "status": "healthy",
+  "message": null
+}
+```
+
+The previous `meilisearch` field is gone. Any monitoring, dashboards, or alerting that referenced `checks.meilisearch` needs to be updated to point at `checks.opensearch`.
+
+Run a search from the web UI or CLI to confirm indexing completed:
+
+```bash
+ak search my-package
+```
+
+## Rollback
+
+If you need to roll back to 1.1.x, revert the backend image tag and restore the Meilisearch service along with the old environment variables. No data migration is needed because the search indexes are derivable from PostgreSQL in both versions.
+
+## Troubleshooting
+
+**OpenSearch container fails to start with `vm.max_map_count` error**
+Raise the setting on the host as shown above. This is a one-time host config, not a container setting.
+
+**Backend logs show TLS errors against OpenSearch**
+Either install a trusted certificate on the OpenSearch node, or set `OPENSEARCH_ALLOW_INVALID_CERTS=true` for dev clusters using the default demo certificates.
+
+**Backend logs show 401 Unauthorized against OpenSearch**
+Verify `OPENSEARCH_USERNAME` and `OPENSEARCH_PASSWORD` match the credentials configured in OpenSearch. The default admin password rules changed in OpenSearch 2.12; if you are running 2.12 or later, ensure the password meets the complexity requirements.
+
+**`/health` still shows `meilisearch` after upgrade**
+The backend still has the old env var set or the old image is still running. Confirm the image tag is `1.2.x` or newer and that `MEILISEARCH_URL` is unset.
+
+**Search returns no results after upgrade**
+The reindex job may still be running. Check the backend logs for indexing progress messages. For very large registries, allow several minutes before reporting the reindex as stuck.

--- a/src/content/docs/docs/deployment/windows.mdx
+++ b/src/content/docs/docs/deployment/windows.mdx
@@ -18,7 +18,7 @@ Deploy Artifact Keeper on Windows Server 2019, 2022, or 2025 as a native Windows
 | **CPU** | 2 cores | 4+ cores |
 | **Disk** | 100 GB for artifact storage | SSD with dedicated volume |
 | **Database** | PostgreSQL 16+ (required) | |
-| **Search** | Meilisearch (optional) | Recommended for full-text search |
+| **Search** | OpenSearch (optional) | Recommended for full-text search |
 
 ## Install PostgreSQL
 
@@ -177,27 +177,32 @@ New-NetFirewallRule -DisplayName "Artifact Keeper API" `
   -Direction Inbound -Protocol TCP -LocalPort 8080 -Action Allow
 ```
 
-If you run Meilisearch on a separate host, also open port 7700. For gRPC clients, open port 9090.
+If you run OpenSearch on a separate host, also open port 9200. For gRPC clients, open port 9090.
 
-## Optional: Meilisearch
+## Optional: OpenSearch
 
-Meilisearch provides fast full-text search for artifacts and metadata. Without it, search falls back to PostgreSQL full-text search, which works but is slower on large registries.
+OpenSearch provides fast full-text search for artifacts and metadata. Without it, search falls back to PostgreSQL full-text search, which works but is slower on large registries.
 
-1. Download the Windows binary from [meilisearch.com](https://www.meilisearch.com/docs/learn/getting_started/installation#local-installation).
+1. Download OpenSearch for Windows from [opensearch.org/downloads](https://opensearch.org/downloads.html). Version 2.19.x is recommended.
 
-2. Run it as a service using [NSSM](https://nssm.cc/):
+2. Extract the archive and run the installer, or use the zip distribution and start it as a Windows Service using [NSSM](https://nssm.cc/):
 
    ```powershell
-   nssm install Meilisearch "C:\Program Files\Meilisearch\meilisearch.exe"
-   nssm set Meilisearch AppParameters "--db-path C:\ProgramData\Meilisearch\data.ms"
-   nssm start Meilisearch
+   nssm install OpenSearch "C:\Program Files\OpenSearch\bin\opensearch.bat"
+   nssm set OpenSearch AppDirectory "C:\Program Files\OpenSearch"
+   nssm start OpenSearch
    ```
 
-3. Add the following to your Artifact Keeper `.env` file:
+3. Set the admin password on first start using the `opensearch-reset-password` tool, then add the following to your Artifact Keeper `.env` file:
 
    ```ini
-   MEILISEARCH_URL=http://localhost:7700
+   OPENSEARCH_URL=https://localhost:9200
+   OPENSEARCH_USERNAME=admin
+   OPENSEARCH_PASSWORD=your-admin-password
+   OPENSEARCH_ALLOW_INVALID_CERTS=true
    ```
+
+   Remove `OPENSEARCH_ALLOW_INVALID_CERTS=true` once you install a trusted TLS certificate for the OpenSearch node.
 
 4. Restart the Artifact Keeper service:
 

--- a/src/content/docs/docs/getting-started/architecture.mdx
+++ b/src/content/docs/docs/getting-started/architecture.mdx
@@ -14,7 +14,7 @@ graph LR
     Backend["Backend<br/>Rust · Axum<br/>45+ format handlers"]
     DB[(PostgreSQL 16)]
     Storage["Storage<br/>Filesystem / S3"]
-    Meili["Meilisearch<br/>Full-text search"]
+    Search["OpenSearch<br/>Full-text search"]
     Trivy["Trivy<br/>Container & FS scanning"]
     Grype["Grype<br/>Dependency scanning"]
     Peer1["Peer Instance"]
@@ -25,7 +25,7 @@ graph LR
     Frontend --> Backend
     Backend --> DB
     Backend --> Storage
-    Backend --> Meili
+    Backend --> Search
     Backend --> Trivy
     Backend --> Grype
     Backend <-->|Borg Replication| Peer1
@@ -40,10 +40,10 @@ graph LR
 | **Backend** (Rust/Axum) | API server, format handlers, business logic | Yes |
 | **PostgreSQL 16** | Metadata, users, scan results, configuration | Yes |
 | **Frontend** (React 19) | Web UI served via Nginx | Optional (API-first) |
-| **Meilisearch** | Full-text search across artifacts and repos | Optional |
+| **OpenSearch** | Full-text search across artifacts and repos | Optional |
 | **Trivy** | Vulnerability scanning for uploaded artifacts | Optional |
 
-Meilisearch, Trivy, and Grype degrade gracefully — the system works without them, just without search or scanning.
+OpenSearch, Trivy, and Grype degrade gracefully. The system works without them, just without search or scanning.
 
 ## Backend Layers
 
@@ -86,7 +86,7 @@ flowchart TD
         direction LR
         PG[(PostgreSQL)]
         FS["Storage<br/>FS / S3"]
-        MS["Meilisearch"]
+        MS["OpenSearch"]
         SC["Trivy / Grype"]
     end
 
@@ -111,7 +111,7 @@ Services contain the business logic. They are injected into handlers via Axum's 
 | `RepositoryService` | CRUD, virtual repo resolution, proxy upstream |
 | `AuthService` | JWT validation, password hashing, token refresh |
 | `ScannerService` | Orchestrates Trivy and Grype, aggregates findings |
-| `MeiliService` | Index management, search queries |
+| `OpenSearchService` | Index management, search queries |
 | `WasmPluginService` | Plugin install, enable, disable, hot reload |
 | `PeerService` | Peer registration, replication coordination |
 | `MigrationService` | Artifactory import orchestration |
@@ -258,7 +258,7 @@ flowchart LR
 | Database | **PostgreSQL 16** | JSONB for flexible metadata, mature tooling, compile-time checked queries via SQLx |
 | Frontend | **React 19 + TypeScript** | Component model, widespread ecosystem, type safety |
 | UI library | **Ant Design 6** | Enterprise-grade components (tables, forms, modals) out of the box |
-| Search | **Meilisearch** | Sub-50ms full-text search, simple to operate, typo tolerance |
+| Search | **OpenSearch** | Mature, Apache 2.0 fork of Elasticsearch, rich query DSL, production-proven at scale |
 | Security scanning | **Trivy + Grype** | Complementary coverage (filesystem + dependency), industry standard, free |
 | Plugin runtime | **Wasmtime** | Sandboxed execution, WIT contracts, broad language support |
 | Storage | **Filesystem / S3** | Simple default for single-node, S3 for cloud-native deployments |

--- a/src/content/docs/docs/getting-started/configuration.mdx
+++ b/src/content/docs/docs/getting-started/configuration.mdx
@@ -90,10 +90,12 @@ services:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `MEILISEARCH_URL` | No | - | MeiliSearch server URL for full-text search (e.g., `http://meilisearch:7700`) |
-| `MEILISEARCH_API_KEY` | No | - | MeiliSearch API key (optional, for protected instances) |
+| `OPENSEARCH_URL` | No | - | OpenSearch server URL for full-text search (e.g., `http://opensearch:9200`) |
+| `OPENSEARCH_USERNAME` | No | - | OpenSearch username (required for the default security plugin) |
+| `OPENSEARCH_PASSWORD` | No | - | OpenSearch password |
+| `OPENSEARCH_ALLOW_INVALID_CERTS` | No | `false` | Skip TLS certificate verification. Only set to `true` for self-signed dev clusters. |
 
-When configured, enables fast full-text search across all artifacts, repositories, and metadata.
+When configured, enables fast full-text search across all artifacts, repositories, and metadata. On first boot the backend auto-reindexes from PostgreSQL, so no data migration step is required.
 
 ## Example Configurations
 
@@ -132,8 +134,9 @@ TRIVY_URL=http://trivy.internal:8080
 SCAN_WORKSPACE_PATH=/var/lib/artifact-keeper/scan-workspace
 
 # Search
-MEILISEARCH_URL=http://meilisearch.internal:7700
-MEILISEARCH_API_KEY=your-meilisearch-master-key
+OPENSEARCH_URL=https://opensearch.internal:9200
+OPENSEARCH_USERNAME=admin
+OPENSEARCH_PASSWORD=your-opensearch-password
 ```
 
 ### Production Configuration (Self-Hosted)
@@ -175,7 +178,10 @@ services:
       - AWS_ACCESS_KEY_ID=minioadmin
       - AWS_SECRET_ACCESS_KEY=minioadmin
       - TRIVY_URL=http://trivy:8080
-      - MEILISEARCH_URL=http://meilisearch:7700
+      - OPENSEARCH_URL=http://opensearch:9200
+      - OPENSEARCH_USERNAME=admin
+      - OPENSEARCH_PASSWORD=admin
+      - OPENSEARCH_ALLOW_INVALID_CERTS=true
 ```
 
 ## Configuration Validation

--- a/src/content/docs/docs/getting-started/installation.mdx
+++ b/src/content/docs/docs/getting-started/installation.mdx
@@ -21,7 +21,7 @@ The included `docker-compose.yml` provides a complete setup:
 | **Web UI** | `ghcr.io/artifact-keeper/artifact-keeper-web` | `artifactkeeper/web` | Next.js frontend |
 | **Caddy** | `caddy:2-alpine` | | Reverse proxy with automatic TLS |
 | **PostgreSQL** | `postgres:16-alpine` | | Metadata database |
-| **Meilisearch** | `getmeili/meilisearch:v1.12` | | Full-text search |
+| **OpenSearch** | `opensearchproject/opensearch:2.19.1` | | Full-text search |
 | **Trivy** | `aquasec/trivy:latest` | | Vulnerability scanning |
 
 > If your organization blocks ghcr.io, use the Docker Hub images instead. Same tags, same content.
@@ -35,7 +35,7 @@ docker compose up -d
 **Default Ports**:
 - Web UI + API: `http://localhost:30080` (HTTP) / `https://localhost:30443` (HTTPS)
 - PostgreSQL: `localhost:30432`
-- Meilisearch: `localhost:7700`
+- OpenSearch: `localhost:9200`
 
 **First-boot setup**: A random admin password is written to `/data/storage/admin.password` inside the container. The API is locked until you change it. Run `docker exec artifact-keeper-backend cat /data/storage/admin.password && echo` to retrieve it. Set `ADMIN_PASSWORD` in your `.env` to skip the setup lock.
 

--- a/src/content/docs/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/docs/getting-started/quickstart.mdx
@@ -38,7 +38,7 @@ This starts the full stack:
 - **Web UI** — Next.js frontend
 - **Caddy** — Reverse proxy (HTTP on port 30080, HTTPS on port 30443)
 - **PostgreSQL 16** — Metadata storage
-- **Meilisearch** — Full-text search
+- **OpenSearch**, full-text search (v2.19.1)
 - **Trivy** — Vulnerability scanning
 
 :::note[Docker Hub alternative]

--- a/src/content/docs/docs/index.mdx
+++ b/src/content/docs/docs/index.mdx
@@ -20,7 +20,7 @@ Artifact Keeper is an open-source artifact registry built to be a powerful, cost
 
 - **Multi-Format Support**: Single registry for all your package types — languages, containers, cloud infrastructure, ML models, and system packages
 - **Security Scanning**: Automatic vulnerability detection with Trivy and Grype, A-F scoring, quarantine policies
-- **Advanced Search**: Fast, full-text search powered by Meilisearch
+- **Advanced Search**: Fast, full-text search powered by OpenSearch
 - **Multi-Auth**: JWT, OIDC, LDAP, SAML 2.0, and API tokens with fine-grained RBAC
 - **Peer Replication**: Deploy full peers closer to your teams with Borg Replication
 - **WASM Plugins**: Extend with custom format handlers written in any WASM-compatible language
@@ -46,4 +46,4 @@ Artifact Keeper is released under the MIT License. Use it freely in your project
 - **Frontend**: React 19 with TypeScript 5.3, Ant Design 6, and TanStack Query 5
 - **Database**: PostgreSQL 16 with compile-time checked queries
 - **Storage**: Filesystem or S3 for artifacts (content-addressed by SHA-256)
-- **Optional**: Trivy + Grype for scanning, Meilisearch for search, MinIO for S3-compatible storage
+- **Optional**: Trivy + Grype for scanning, OpenSearch for search, MinIO for S3-compatible storage

--- a/src/content/docs/docs/monitoring/health-checks.mdx
+++ b/src/content/docs/docs/monitoring/health-checks.mdx
@@ -11,7 +11,7 @@ Artifact Keeper exposes multiple health check endpoints, each designed for a spe
 |----------|---------|------------------|-----------------|
 | `/livez` | Liveness probe | None (if Axum routes the request, the process is alive) | Kubernetes `livenessProbe` |
 | `/readyz` | Readiness probe | Database connectivity, migrations, setup completion | Kubernetes `readinessProbe` and `startupProbe` |
-| `/health` | Full health dashboard | Database, Trivy, Meilisearch, OpenSCAP, Dependency-Track, storage backend, DB pool stats | Monitoring dashboards, alerting |
+| `/health` | Full health dashboard | Database, Trivy, OpenSearch, OpenSCAP, Dependency-Track, storage backend, DB pool stats | Monitoring dashboards, alerting |
 | `/healthz` | Alias for `/health` | Same as `/health` | Monitoring dashboards |
 | `/ready` | Legacy alias for `/readyz` | Same as `/readyz` | Backward compatibility |
 
@@ -65,7 +65,7 @@ Performs a comprehensive check of every dependent service and includes database 
 
 - **Database** -- connection and query execution
 - **Trivy** -- vulnerability scanner reachability
-- **Meilisearch** -- search engine reachability
+- **OpenSearch** -- search engine reachability (`/_cluster/health`)
 - **OpenSCAP** -- compliance scanner reachability
 - **Dependency-Track** -- SBOM analysis platform reachability
 - **Storage backend** -- active read/write probe (see [Storage Health Check Details](#storage-health-check-details))
@@ -74,7 +74,7 @@ Performs a comprehensive check of every dependent service and includes database 
 Returns `200 OK` when all services are healthy, or `503 Service Unavailable` when any service is degraded.
 
 :::caution
-Do not use `/health` as a Kubernetes liveness probe. If an external service like Trivy or Meilisearch goes down, the `/health` endpoint returns 503, which would cause Kubernetes to restart your backend pods -- even though the backend itself is functioning correctly. This creates cascading failures. Use `/livez` for liveness instead.
+Do not use `/health` as a Kubernetes liveness probe. If an external service like Trivy or OpenSearch goes down, the `/health` endpoint returns 503, which would cause Kubernetes to restart your backend pods, even though the backend itself is functioning correctly. This creates cascading failures. Use `/livez` for liveness instead.
 :::
 
 ## Response Examples
@@ -135,7 +135,7 @@ curl -s http://localhost:8080/health | jq .
       "status": "healthy",
       "message": null
     },
-    "meilisearch": {
+    "opensearch": {
       "status": "healthy",
       "message": null
     },
@@ -197,7 +197,7 @@ containers:
 
 **`startupProbe` uses `/readyz`** -- During startup, the server needs time to connect to PostgreSQL and run migrations. The startup probe gives it up to 150 seconds (5s period x 30 failures) before Kubernetes considers the container failed. Once the startup probe succeeds, the liveness and readiness probes take over.
 
-**`livenessProbe` uses `/livez`** -- The liveness probe answers one question: is the process still running and able to handle HTTP requests? By using `/livez`, which has zero external dependencies, you avoid cascading restarts when a downstream service (database, Trivy, Meilisearch) is temporarily unavailable. Kubernetes only restarts the pod if the backend process itself is hung or crashed.
+**`livenessProbe` uses `/livez`** -- The liveness probe answers one question: is the process still running and able to handle HTTP requests? By using `/livez`, which has zero external dependencies, you avoid cascading restarts when a downstream service (database, Trivy, OpenSearch) is temporarily unavailable. Kubernetes only restarts the pod if the backend process itself is hung or crashed.
 
 **`readinessProbe` uses `/readyz`** -- The readiness probe controls whether the pod receives traffic. If the database becomes unreachable or migrations are pending after a rolling update, `/readyz` returns 503 and Kubernetes removes the pod from the Service endpoints. Traffic shifts to healthy pods without restarting anything.
 
@@ -311,7 +311,7 @@ The storage health check performs real I/O operations. Common causes of failure:
 
 ### `/health` showing unhealthy external services
 
-External service checks (Trivy, Meilisearch, OpenSCAP, Dependency-Track) report unhealthy when the service is unreachable or not responding.
+External service checks (Trivy, OpenSearch, OpenSCAP, Dependency-Track) report unhealthy when the service is unreachable or not responding.
 
 :::tip
 External service failures do not affect `/livez` or `/readyz`. The backend continues to serve artifacts and API requests normally -- only features that depend on the specific service (vulnerability scanning, full-text search, compliance checks) are degraded.
@@ -323,9 +323,9 @@ To diagnose:
   ```bash
   curl -s http://localhost:8090/healthz
   ```
-- **Meilisearch unhealthy** -- Verify `MEILISEARCH_URL` and check if the Meilisearch process is running:
+- **OpenSearch unhealthy** -- Verify `OPENSEARCH_URL` and check if the OpenSearch process is running:
   ```bash
-  curl -s http://localhost:7700/health
+  curl -s -u admin:admin -k https://localhost:9200/_cluster/health
   ```
 - **OpenSCAP unhealthy** -- Verify the OpenSCAP service is running on port 8091
 - **Dependency-Track unhealthy** -- Verify Dependency-Track is running on port 8092

--- a/src/content/docs/docs/package-formats.mdx
+++ b/src/content/docs/docs/package-formats.mdx
@@ -195,7 +195,7 @@ Every format supports the full Artifact Keeper feature set:
 | Upload / Download | All formats |
 | Versioning | All formats |
 | Metadata Indexing | All formats |
-| Full-Text Search | All formats (via Meilisearch) |
+| Full-Text Search | All formats (via OpenSearch) |
 | Access Control (RBAC) | All formats |
 | Vulnerability Scanning | Language packages, containers, archives |
 | Repository Metadata Signing | Debian, RPM, Alpine, Conda |

--- a/src/content/docs/docs/reference/environment.mdx
+++ b/src/content/docs/docs/reference/environment.mdx
@@ -279,14 +279,16 @@ Read by the **backend** process.
 | `CACHE_TTL_SECONDS` | No | `3600` | Cache TTL (1 hour) |
 | `CACHE_SIZE_MB` | No | `1024` | Cache size (1 GB) |
 
-## Search (Meilisearch)
+## Search (OpenSearch)
 
-Search is powered by [Meilisearch](https://www.meilisearch.com/). When `MEILISEARCH_URL` is set, the backend indexes artifacts for full-text search. Read by the **backend** process.
+Search is powered by [OpenSearch](https://opensearch.org/). When `OPENSEARCH_URL` is set, the backend indexes artifacts for full-text search. On first boot the backend auto-reindexes from PostgreSQL, so no data migration step is required. Read by the **backend** process.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `MEILISEARCH_URL` | No | - | Meilisearch server URL (e.g., `http://meilisearch:7700`). Search is disabled when unset. |
-| `MEILISEARCH_API_KEY` | No | - | Meilisearch master key for authentication |
+| `OPENSEARCH_URL` | No | - | OpenSearch server URL (e.g., `https://opensearch:9200`). Search is disabled when unset. |
+| `OPENSEARCH_USERNAME` | No | - | OpenSearch username (required when the security plugin is enabled, which is the default) |
+| `OPENSEARCH_PASSWORD` | No | - | OpenSearch password |
+| `OPENSEARCH_ALLOW_INVALID_CERTS` | No | `false` | Skip TLS certificate verification. Only set to `true` for self-signed dev clusters. |
 
 ## CORS
 


### PR DESCRIPTION
## Summary

Companion docs PR for [artifact-keeper/artifact-keeper#830](https://github.com/artifact-keeper/artifact-keeper/pull/830), which replaces Meilisearch with OpenSearch 2.19.1 as the backend search engine.

Updates every user-facing mention of the search service across the docs site:

- Prose references: Meilisearch to OpenSearch
- Config examples: `MEILISEARCH_URL` / `MEILISEARCH_API_KEY` to `OPENSEARCH_URL` / `OPENSEARCH_USERNAME` / `OPENSEARCH_PASSWORD` / `OPENSEARCH_ALLOW_INVALID_CERTS`
- Ports: 7700 to 9200
- Images: `getmeili/meilisearch:v1.12` to `opensearchproject/opensearch:2.19.1`
- Health check path: `/health` to `/_cluster/health`
- Health response field: `meilisearch` to `opensearch`

Files touched:

- `src/content/docs/docs/index.mdx`
- `src/content/docs/docs/package-formats.mdx`
- `src/content/docs/docs/cli/tui.mdx`
- `src/content/docs/docs/advanced/edge-nodes.mdx`
- `src/content/docs/docs/getting-started/{architecture,configuration,installation,quickstart}.mdx`
- `src/content/docs/docs/deployment/{aws,docker,helm,windows}.mdx`
- `src/content/docs/docs/monitoring/health-checks.mdx`
- `src/content/docs/docs/reference/environment.mdx`
- `astro.config.mjs` (new sidebar entry for the migration page)

New page:

- `src/content/docs/docs/deployment/migration-meili-to-opensearch.mdx` covers the 1.1 to 1.2 upgrade path: stop Meilisearch, deploy OpenSearch, update env vars, restart the backend to trigger auto-reindex from PostgreSQL, verify via `/health`. No search data migration required.

The chart schema change (top-level `opensearch:` values block) lands in a companion PR to `artifact-keeper-iac`. The Helm page mentions this and points operators at the migration guide.

## Test Checklist
- [x] `npm run build` passes (69 pages built, no warnings)
- [x] Verified sidebar slug resolves correctly
- [x] No broken internal links introduced
- [x] No em-dashes or emoji in new content (per CLAUDE.md writing style)
- [x] Followed project writing style: direct, no marketing polish

## Open Questions

- Placement of the migration page under "Deployment" feels right given operators are the audience, but it could also live under a future "Upgrading" section if one is planned.
- Sidebar label "Migrate 1.1 to 1.2 (OpenSearch)" is verbose; shortening to "1.2 OpenSearch Migration" is an option if that reads better.