### PR TITLE
docs: prepare for v1.2.0 release (callouts, release notes, support policy)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig({
             { label: 'Quickstart', slug: 'docs/getting-started/quickstart' },
             { label: 'Installation', slug: 'docs/getting-started/installation' },
             { label: 'Configuration', slug: 'docs/getting-started/configuration' },
+            { label: 'Support Policy', slug: 'docs/getting-started/support-policy' },
           ],
         },
         {
@@ -129,6 +130,12 @@ export default defineConfig({
             { label: 'Environment Variables', slug: 'docs/reference/environment' },
             { label: 'CI/CD Integration', slug: 'docs/guides/ci-cd' },
             { label: 'UI Gallery', slug: 'docs/ui-gallery' },
+          ],
+        },
+        {
+          label: 'Release Notes',
+          items: [
+            { label: 'v1.2.0', slug: 'docs/release-notes/v1-2-0' },
           ],
         },
       ],

--- a/src/content/docs/docs/deployment/aws.mdx
+++ b/src/content/docs/docs/deployment/aws.mdx
@@ -3,6 +3,10 @@ title: "AWS Deployment"
 description: "Deploy Artifact Keeper on AWS using a pre-built AMI or Packer + Terraform"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 Deploy Artifact Keeper on a single EC2 instance using Docker Compose. The AMI comes with Docker pre-installed, all images pre-pulled, and a first-boot service that generates secrets and starts everything automatically.
 
 ## Architecture

--- a/src/content/docs/docs/deployment/docker.mdx
+++ b/src/content/docs/docs/deployment/docker.mdx
@@ -3,6 +3,10 @@ title: "Docker Compose Deployment"
 description: "Deploy Artifact Keeper using Docker Compose with all services"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 Deploy Artifact Keeper using Docker Compose for a complete, containerized setup.
 
 ## Prerequisites

--- a/src/content/docs/docs/deployment/helm.mdx
+++ b/src/content/docs/docs/deployment/helm.mdx
@@ -5,6 +5,10 @@ description: "Deploy Artifact Keeper on Kubernetes using the official Helm chart
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 :::caution[Example Configuration]
 The Helm chart, Terraform modules, ArgoCD configs, and monitoring stack are provided as **getting started templates**. They should be reviewed and modified to match your specific infrastructure requirements, security policies, and operational needs before use in production.
 :::

--- a/src/content/docs/docs/deployment/windows.mdx
+++ b/src/content/docs/docs/deployment/windows.mdx
@@ -3,6 +3,10 @@ title: "Windows Server"
 description: "Deploy Artifact Keeper as a Windows Service with PostgreSQL on Windows Server"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 :::caution[Beta Support]
 Windows support is currently in **beta**. The core functionality works, but you may encounter rough edges. If you run into issues, please report them on [GitHub](https://github.com/artifact-keeper/artifact-keeper/issues).
 :::

--- a/src/content/docs/docs/getting-started/architecture.mdx
+++ b/src/content/docs/docs/getting-started/architecture.mdx
@@ -3,6 +3,10 @@ title: Architecture
 description: "How Artifact Keeper is built: system design, technology choices, and the reasoning behind them."
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 Artifact Keeper is designed as a modular, layered system. This page walks through every major component so you can evaluate whether the architecture fits your needs and contribute with full context.
 
 ## System Overview

--- a/src/content/docs/docs/getting-started/configuration.mdx
+++ b/src/content/docs/docs/getting-started/configuration.mdx
@@ -3,6 +3,10 @@ title: "Configuration"
 description: "Complete environment variable reference for Artifact Keeper"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 # Configuration
 
 Artifact Keeper is configured using environment variables. All configuration options are documented below.

--- a/src/content/docs/docs/getting-started/installation.mdx
+++ b/src/content/docs/docs/getting-started/installation.mdx
@@ -3,6 +3,10 @@ title: "Installation"
 description: "Install Artifact Keeper using Docker Compose or build from source"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 # Installation
 
 Artifact Keeper can be deployed using Docker Compose for quick setup, or built from source for customization.

--- a/src/content/docs/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/docs/getting-started/quickstart.mdx
@@ -3,6 +3,10 @@ title: "Quickstart"
 description: "Get Artifact Keeper running in 5 minutes with Docker Compose"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 # Quickstart
 
 Get Artifact Keeper up and running in minutes using Docker Compose.

--- a/src/content/docs/docs/getting-started/support-policy.mdx
+++ b/src/content/docs/docs/getting-started/support-policy.mdx
@@ -1,0 +1,34 @@
+---
+title: Support Policy
+description: Which Artifact Keeper versions are supported, what kind of fixes land where, and when versions reach end of life.
+---
+
+Artifact Keeper follows semantic versioning. We support the latest two minor versions. Security backports land on the previous minor; feature work targets the latest minor only.
+
+## Supported versions
+
+| Version | Status      | Support                                       |
+|---------|-------------|-----------------------------------------------|
+| 1.2.x   | Active      | Bug fixes, security patches, feature work     |
+| 1.1.x   | Maintenance | Security patches only, until v1.3.0 ships     |
+| &lt;= 1.0.x  | End of life | Upgrade required                              |
+
+## What this means in practice
+
+- **Active**: the line where new features land. All bug fixes and security patches go here first. This is where you should run production deployments.
+- **Maintenance**: receives security backports only. No new features, no functional bug fixes. When the next minor (v1.3.0) ships, this line moves to end of life and v1.2.x becomes the maintenance line.
+- **End of life**: no further fixes of any kind. Reported issues will be closed with a request to upgrade. Container images remain available on `ghcr.io` indefinitely so existing deployments are not broken, but no patches will be issued.
+
+Security backports for the maintenance line land on the `release/1.1.x` branch and are published as `1.1.x` patch releases (for example, `1.1.9`, `1.1.10`).
+
+## Cadence
+
+Minor versions ship roughly every 8 to 12 weeks. Patch releases ship as needed for critical bug fixes and security advisories, sometimes within hours of a CVE disclosure.
+
+## What "supported" means for SDKs
+
+Client SDKs (npm `@artifact-keeper/sdk`, Maven, PyPI, crates.io, SPM) are versioned in lock-step with the backend. SDK major.minor matches the backend major.minor it was generated against. A 1.2.x SDK is guaranteed to work against any 1.2.x backend; cross-minor compatibility (for example, 1.1.x SDK against 1.2.x backend) is not guaranteed but is usually maintained for read-only operations.
+
+## Reporting security issues
+
+Security issues should never be reported as public GitHub issues. See [SECURITY.md](https://github.com/artifact-keeper/artifact-keeper/blob/main/SECURITY.md) for the private disclosure channel.

--- a/src/content/docs/docs/monitoring/health-checks.mdx
+++ b/src/content/docs/docs/monitoring/health-checks.mdx
@@ -3,6 +3,10 @@ title: "Health Checks"
 description: "Health check endpoints for Kubernetes probes, Docker healthchecks, and monitoring dashboards"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 Artifact Keeper exposes multiple health check endpoints, each designed for a specific use case. Lightweight probes keep Kubernetes from restarting pods unnecessarily, while the full health dashboard gives operators visibility into every dependent service.
 
 ## Endpoints Reference

--- a/src/content/docs/docs/reference/environment.mdx
+++ b/src/content/docs/docs/reference/environment.mdx
@@ -3,6 +3,10 @@ title: "Environment Variables"
 description: "Complete reference of all environment variables for configuring Artifact Keeper"
 ---
 
+:::caution[Upgrading from 1.1.x?]
+This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::
+
 Configure Artifact Keeper using environment variables. This page provides a complete reference of all available configuration options.
 
 ## Core Settings

--- a/src/content/docs/docs/release-notes/v1-2-0.mdx
+++ b/src/content/docs/docs/release-notes/v1-2-0.mdx
@@ -1,0 +1,63 @@
+---
+title: What's new in 1.2.0
+description: Headline changes, breaking changes, and migration steps for v1.2.0
+---
+
+v1.2.0 is the second minor release of Artifact Keeper. The headline change is the search backend swap from Meilisearch to OpenSearch, which is a breaking change for existing operators. This page summarises everything you need to know to upgrade.
+
+For the full commit-level changelog, see [the GitHub release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.2.0).
+
+## Headline changes
+
+- **Search backend swap to OpenSearch** ([#462](https://github.com/artifact-keeper/artifact-keeper/issues/462)). The search backend moved from Meilisearch to OpenSearch. The motivation is operational: OpenSearch supports multi-node clustering and high availability without an Enterprise license, which Meilisearch does not. Existing search functionality (full-text search across artifacts, repos, and metadata) is preserved. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for the upgrade procedure.
+- **Public runtime config endpoint** ([#496](https://github.com/artifact-keeper/artifact-keeper/issues/496)). A new unauthenticated `GET /api/v1/system/config` endpoint exposes feature flags, version, and public runtime configuration. The web UI uses it to render features dynamically without baking config into the JavaScript bundle. See the [REST API reference](/docs/reference/api/).
+- **Unauthenticated metrics endpoint** ([#570](https://github.com/artifact-keeper/artifact-keeper/issues/570)). Prometheus scraping no longer requires a bearer token. The endpoint can still be locked down at the network or reverse-proxy layer. See [Prometheus Metrics](/docs/monitoring/metrics/).
+- **Expanded presigned URL coverage** ([#604](https://github.com/artifact-keeper/artifact-keeper/issues/604)). More format handlers now redirect downloads to S3 presigned URLs when `S3_REDIRECT_DOWNLOADS=true`, reducing backend bandwidth and CPU. See [Storage Backends](/docs/advanced/storage/).
+- **Quality gate quarantine period** ([#472](https://github.com/artifact-keeper/artifact-keeper/issues/472)). Newly published artifacts can be held in quarantine for a configurable window before they become consumable, giving scanners time to complete and signing workflows time to run. See [Quality Gates](/docs/security/quality-gates/).
+- **Maven remote artifact grouping** ([#641](https://github.com/artifact-keeper/artifact-keeper/issues/641)). The UI groups Maven remote artifacts by component name and version instead of listing every classifier and checksum file separately.
+- **Hex virtual repo merging** ([#346](https://github.com/artifact-keeper/artifact-keeper/issues/346)). Hex `list_names` and `list_versions` endpoints now correctly merge results across virtual repo members.
+- **Trivy and Grype Go CVE patches** ([#403](https://github.com/artifact-keeper/artifact-keeper/issues/403)). The bundled Trivy and Grype binaries were rebuilt against a patched Go toolchain to clear upstream Go CVEs.
+
+## Breaking changes
+
+- **Search env vars renamed**: `MEILISEARCH_URL` and `MEILISEARCH_API_KEY` are removed. Replace with:
+  - `OPENSEARCH_URL` (e.g., `https://opensearch.internal:9200`)
+  - `OPENSEARCH_USERNAME` (default: `admin`)
+  - `OPENSEARCH_PASSWORD`
+  - `OPENSEARCH_ALLOW_INVALID_CERTS` (default `false`, set `true` only for self-signed dev certs)
+- **Search port changed**: `7700` (Meilisearch) is no longer used. OpenSearch listens on `9200`. Update firewall rules, network policies, and service definitions.
+- **Health response field renamed**: The `/health` and `/healthz` JSON payload now reports the search backend under `opensearch` instead of `meilisearch`. If you have monitoring that parses this field by name, update it.
+- **Helm values renamed**: The chart removes the `meilisearch.*` block and adds an `opensearch.*` block. See the migration guide.
+- **Docker Compose service renamed**: The `meilisearch` service in the bundled compose file is replaced by `opensearch`. Pre-existing volumes named `meilisearch_data` are no longer mounted; OpenSearch uses `opensearch_data`. The search index is rebuilt from PostgreSQL on first start, so no artifact data is lost.
+
+## Bug fixes worth calling out
+
+- **Maven virtual repo SNAPSHOT artifacts** ([#839](https://github.com/artifact-keeper/artifact-keeper/issues/839)). Virtual Maven repos now correctly resolve `-SNAPSHOT` artifacts from member repos. Previously, requests for snapshots through a virtual repo returned 404 even when the artifact existed in a member.
+- **Debian APT route panic on startup** ([#832](https://github.com/artifact-keeper/artifact-keeper/issues/832)). The backend no longer panics on startup when the APT format dists route is registered. The route pattern was rewritten to use a non-conflicting parameter capture.
+- **Nexus migration: yum and maven2 formats** ([#857](https://github.com/artifact-keeper/artifact-keeper/issues/857)). The Nexus migration engine now recognises Nexus's native `yum` and `maven2` format names and maps them to the corresponding Artifact Keeper handlers.
+- **Nexus migration: checksum mismatch handling** ([#856](https://github.com/artifact-keeper/artifact-keeper/issues/856)). The migration engine handles Nexus's dual-checksum (sha1 and sha256) verification correctly and no longer aborts on benign mismatches.
+- **wasmtime aarch64 sandbox-escape CVE** ([#691](https://github.com/artifact-keeper/artifact-keeper/issues/691), RUSTSEC-2026-0096). wasmtime was bumped to 36.0.7, which closes a sandbox-escape vulnerability affecting WASM plugin hosts on aarch64.
+
+## Upgrade path
+
+1. **Read the [migration guide](/docs/deployment/migration-meili-to-opensearch/)** end to end before starting. The search backend swap requires an OpenSearch instance to be running before you start the new backend.
+2. **Pull the new images**:
+   ```bash
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:1.2.0
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-web:1.2.0
+   ```
+3. **Helm**: bump the chart to the v1.2.0-compatible version. Remove the `meilisearch:` block from your values file and replace it with the `opensearch:` block. Apply with `helm upgrade`.
+4. **Docker Compose**: pull the v1.2.0 compose file from the release tarball, copy in your `.env`, and run `docker compose up -d`. The compose file replaces the `meilisearch` service with `opensearch`.
+5. **AWS AMI**: re-run the latest first-boot script, or rebuild the AMI from the v1.2.0 Packer template.
+6. **Self-hosted scripts**: re-run `scripts/install.sh` from the v1.2.0 release tarball. The installer detects an existing Meilisearch service, stops it, and provisions OpenSearch in its place.
+7. **Verify**: hit `/health` and confirm the `opensearch` field reports `healthy`. Run a search query in the web UI to confirm indexes were rebuilt.
+
+The web UI, CLI, and native clients (iOS, Android) work unchanged against a 1.2.0 backend. SDKs published to npm, Maven, PyPI, crates.io, and SPM are tagged `1.2.0`.
+
+## Support window
+
+- **1.2.x**: active. Bug fixes, security patches, and feature work all land here.
+- **1.1.x**: maintenance only. Security backports until v1.3.0 ships.
+- **&lt;= 1.0.x**: end of life. Upgrade required.
+
+See [Support Policy](/docs/getting-started/support-policy/) for the full version-support matrix.


### PR DESCRIPTION
## Summary

Prepares the site for the v1.2.0 release. This is a follow-up to #59
(chore/462-opensearch-docs), which swaps Meilisearch for OpenSearch
across the docs and adds the migration guide page. This PR adds the
remaining v1.2.0 doc surfaces:

- **1.1.x to 1.2.x upgrade callout** on 10 pages whose content
  meaningfully differs between 1.1.x and 1.2.x. Each callout points at
  the OpenSearch migration guide delivered by #59.
  - `getting-started/{architecture, quickstart, installation, configuration}`
  - `deployment/{helm, aws, docker, windows}`
  - `reference/environment`
  - `monitoring/health-checks`
- **New "What's new in 1.2.0" page** at
  `docs/release-notes/v1-2-0.mdx`. Headline features (sourced from the
  v1.2.0 milestone label), breaking changes, bug fixes worth calling
  out (#839, #832, #857, #856, #691), and an upgrade path. Wired into
  a new "Release Notes" sidebar section.
- **New Support Policy page** at
  `docs/getting-started/support-policy.mdx` with the version-support
  matrix (1.2.x active, 1.1.x maintenance, less than or equal 1.0.x EOL)
  plus cadence and SDK-versioning guidance. Wired into the
  Getting Started sidebar.

## Dependency on #59

This PR depends on #59 merging first. The callouts and release notes
both link to `/docs/deployment/migration-meili-to-opensearch/`, which
is the page added by #59. If #59 lands first, those links resolve
cleanly. If this PR somehow lands first, those links will 404 until
#59 merges, which is an acceptable transient state during the release
window. There are no merge conflicts between the two branches; the
file sets are disjoint except for `astro.config.mjs`, which both
edit (#59 does not currently touch the sidebar in a way that
conflicts with the additions here).

## Test Checklist

- [x] `npm run build` passes (70 pages built, no MDX errors, no
      sidebar slug errors)
- [x] Verified page renders correctly locally (build artifacts include
      `dist/docs/release-notes/v1-2-0/index.html` and
      `dist/docs/getting-started/support-policy/index.html`)
- [x] Links are valid (links to the migration guide assume #59 has
      merged; verified the slug pattern matches what #59 adds)
- [x] No regressions on other pages
- [x] No em-dashes, no emoji, no AI co-author lines

## Open questions / TODO

- The release notes link to a few feature pages (quality gates, public
  config endpoint, expanded presigned URLs) that may or may not have
  matching docs. Quality Gates and Storage are confirmed. The
  unauthenticated metrics endpoint lands on the existing metrics page;
  no new dedicated page added here.
- The `GET /api/v1/system/config` endpoint may warrant a section in
  `reference/api.mdx`. Not added in this PR because the user-facing
  contract is small and the endpoint is mostly for the web UI to
  consume. Flagged for a follow-up if needed.
- The release-notes filename uses `v1-2-0.mdx` (not `v1.2.0.mdx`)
  because Starlight's content-collection slugs reject literal dots in
  file names. The visible label remains "v1.2.0".