### PR TITLE
docs(deployment): add v1.1.x to v1.2.0 search-backend transition callouts (#61)

### DIFF
--- a/src/content/docs/docs/deployment/aws.mdx
+++ b/src/content/docs/docs/deployment/aws.mdx
@@ -3,8 +3,12 @@ title: "AWS Deployment"
 description: "Deploy Artifact Keeper on AWS using a pre-built AMI or Packer + Terraform"
 ---
 
-:::caution[Upgrading from 1.1.x?]
-This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::caution[v1.1.x to v1.2.0 search backend transition]
+This page describes the v1.2.0 layout. **v1.2.0 is not yet released**; the latest stable line is v1.1.x, which uses Meilisearch. The OpenSearch service in the architecture diagram and Packer/Terraform configs below applies only when you run a v1.2.0 build (currently `main` and pre-releases).
+
+The pre-built AMI tracks the latest release line. If you launch the AMI today you get a v1.1.x image with Meilisearch on port 7700; the OpenSearch layout takes effect once the v1.2.0 AMI is published.
+
+See the [v1.2.0 CHANGELOG entry](https://github.com/artifact-keeper/artifact-keeper/blob/main/CHANGELOG.md), [issue #830](https://github.com/artifact-keeper/artifact-keeper/issues/830), and the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
 :::
 
 Deploy Artifact Keeper on a single EC2 instance using Docker Compose. The AMI comes with Docker pre-installed, all images pre-pulled, and a first-boot service that generates secrets and starts everything automatically.

--- a/src/content/docs/docs/deployment/docker.mdx
+++ b/src/content/docs/docs/deployment/docker.mdx
@@ -3,8 +3,12 @@ title: "Docker Compose Deployment"
 description: "Deploy Artifact Keeper using Docker Compose with all services"
 ---
 
-:::caution[Upgrading from 1.1.x?]
-This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::caution[v1.1.x to v1.2.0 search backend transition]
+This page describes the v1.2.0 layout. **v1.2.0 is not yet released**; the latest stable line is v1.1.x, which uses Meilisearch. The OpenSearch service, ports, and env vars shown below apply only when you run a v1.2.0 build (currently `main` and pre-releases).
+
+If you are deploying current stable (v1.1.x), use the v1.1.x `docker-compose.yml` from that release tag, which ships with Meilisearch instead of OpenSearch. The CLI commands, volume layout, and Caddy routing on this page apply to both versions.
+
+See the [v1.2.0 CHANGELOG entry](https://github.com/artifact-keeper/artifact-keeper/blob/main/CHANGELOG.md), [issue #830](https://github.com/artifact-keeper/artifact-keeper/issues/830), and the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
 :::
 
 Deploy Artifact Keeper using Docker Compose for a complete, containerized setup.

--- a/src/content/docs/docs/deployment/helm.mdx
+++ b/src/content/docs/docs/deployment/helm.mdx
@@ -5,8 +5,12 @@ description: "Deploy Artifact Keeper on Kubernetes using the official Helm chart
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-:::caution[Upgrading from 1.1.x?]
-This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::caution[v1.1.x to v1.2.0 search backend transition]
+This page describes the v1.2.0 layout. **v1.2.0 is not yet released**; the latest stable line is v1.1.x, which uses Meilisearch. The OpenSearch service, ports, and env vars shown below apply only when you run a v1.2.0 build (currently `main` and pre-releases).
+
+If you are deploying current stable (v1.1.x), substitute the Meilisearch service from the v1.1.x chart values and ignore the OpenSearch parameters.
+
+See the [v1.2.0 CHANGELOG entry](https://github.com/artifact-keeper/artifact-keeper/blob/main/CHANGELOG.md), [issue #830](https://github.com/artifact-keeper/artifact-keeper/issues/830), and the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
 :::
 
 :::caution[Example Configuration]

--- a/src/content/docs/docs/deployment/windows.mdx
+++ b/src/content/docs/docs/deployment/windows.mdx
@@ -3,8 +3,12 @@ title: "Windows Server"
 description: "Deploy Artifact Keeper as a Windows Service with PostgreSQL on Windows Server"
 ---
 
-:::caution[Upgrading from 1.1.x?]
-This page describes 1.2.x and later. The search backend changed from Meilisearch to OpenSearch. See the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
+:::caution[v1.1.x to v1.2.0 search backend transition]
+This page describes the v1.2.0 layout. **v1.2.0 is not yet released**; the latest stable line is v1.1.x, which uses Meilisearch as the optional search backend. The OpenSearch service and env vars shown below apply only when you run a v1.2.0 build.
+
+If you are deploying current stable (v1.1.x) on Windows, the optional search service is Meilisearch (port 7700), configured with `MEILISEARCH_URL` and `MEILISEARCH_API_KEY`. Without it, search falls back to PostgreSQL full-text search.
+
+See the [v1.2.0 CHANGELOG entry](https://github.com/artifact-keeper/artifact-keeper/blob/main/CHANGELOG.md), [issue #830](https://github.com/artifact-keeper/artifact-keeper/issues/830), and the [migration guide](/docs/deployment/migration-meili-to-opensearch/) for env var changes, port changes, and rollout steps.
 :::
 
 :::caution[Beta Support]


### PR DESCRIPTION
## Summary

Strengthens the version-transition callouts on the four deployment guides (helm, docker, windows, aws) so that readers on stable v1.1.x are not misled by the OpenSearch instructions, which apply only to v1.2.0 builds (currently `main` and pre-releases).

The previous callout title was "Upgrading from 1.1.x?", which a fresh v1.1.x installer would correctly read as "not me" and skip past, then follow OpenSearch instructions that do not match their installed version. The new callout title leads with "v1.1.x to v1.2.0 search backend transition" and the body explicitly says v1.2.0 is not yet released, names what each version uses, and tells v1.1.x readers what to substitute on the page they are on.

Each callout now links the v1.2.0 CHANGELOG entry and artifact-keeper#830 alongside the existing migration guide link, as the issue requested.

## Note on scope

Issue #61 was filed before the search-backend documentation flip in PRs #59 and #60. At the time the issue was written, the deployment pages still described Meilisearch as primary, and the ask was to add forward-warning callouts. By the time work started, those pages already documented OpenSearch as primary with `:::caution` callouts pointing to a migration guide.

This PR therefore implements the spirit of #61 (clear version-aware transition warning, links to CHANGELOG and #830, no primary content flipped further) by tightening the existing callouts rather than adding new ones. The umbrella flip-completion is still tracked under #62; these strengthened callouts can be removed or reworded as historical notes once v1.2.0 ships.

## Files changed

- `src/content/docs/docs/deployment/helm.mdx`
- `src/content/docs/docs/deployment/docker.mdx`
- `src/content/docs/docs/deployment/windows.mdx`
- `src/content/docs/docs/deployment/aws.mdx`

## Test Checklist

- [x] `npm run build` passes (71 pages built, 0 errors)
- [x] Verified callout MDX renders (Starlight `:::caution[title]` syntax matches existing usage in the file)
- [x] Links are valid (CHANGELOG and issue #830 are absolute GitHub URLs; migration guide path was already in the file and unchanged)
- [x] Images load correctly (no image changes)
- [x] No regressions on other pages (only four deployment pages touched, callout-only edits)

Fixes #61