### PR TITLE
docs(advanced/remote-virtual): correct cache TTL endpoint URL, body, and add GET

### DIFF
--- a/src/content/docs/docs/advanced/remote-virtual.mdx
+++ b/src/content/docs/docs/advanced/remote-virtual.mdx
@@ -68,14 +68,36 @@ The `upstream_url` field is required for remote repositories and should point to
 
 ### Configuring Cache TTL
 
-Set a custom cache TTL per repository:
+Set a custom cache TTL on a remote repository:
 
 ```bash
-curl -X PUT "http://localhost:8080/api/v1/repositories/pypi-remote/config/cache_ttl_secs" \
+curl -X PUT "http://localhost:8080/api/v1/repositories/pypi-remote/cache-ttl" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $TOKEN" \
-  -d '{"value": "3600"}'
+  -d '{"cache_ttl_seconds": 3600}'
 ```
+
+`cache_ttl_seconds` must be between `1` and `2592000` (30 days). Writes are
+only accepted on remote (proxy) repositories.
+
+Read the current TTL for any repository:
+
+```bash
+curl -X GET "http://localhost:8080/api/v1/repositories/pypi-remote/cache-ttl" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Response:
+
+```json
+{
+  "repository_key": "pypi-remote",
+  "cache_ttl_seconds": 86400
+}
+```
+
+If no TTL has been set explicitly, the response reports the default the proxy
+will actually apply (`86400` seconds = 24 hours).
 
 ### Write Protection
 


### PR DESCRIPTION
## Summary

The "Configuring Cache TTL" example on
[`docs/advanced/remote-virtual`](https://artifactkeeper.com/docs/advanced/remote-virtual)
pointed at a route that does not exist — `PUT /api/v1/repositories/{key}/config/cache_ttl_secs`
with body `{"value": "..."}` — and returned 404 for any reader who copy-pasted it.

This PR:

1. Corrects the PUT example to the route the backend actually registers in
   [`artifact-keeper/backend/src/api/handlers/repositories.rs`](https://github.com/artifact-keeper/artifact-keeper/blob/main/backend/src/api/handlers/repositories.rs):
   `PUT /api/v1/repositories/{key}/cache-ttl` with body `{"cache_ttl_seconds": <int>}`.
2. Documents the sibling `GET /api/v1/repositories/{key}/cache-ttl` endpoint and
   the shape of `CacheTtlResponse` (`{"repository_key": ..., "cache_ttl_seconds": ...}`),
   noting that GET falls back to the proxy default (86400s = 24h) when no value
   has been written via PUT.
3. Notes the `1..=2592000` (30 days) validation range and the remote-only
   restriction enforced by `is_cache_ttl_configurable()` on the PUT path.

The OpenAPI spec at
[`artifact-keeper-api/openapi.yaml`](https://github.com/artifact-keeper/artifact-keeper-api/blob/main/openapi.yaml)
already documents the correct shape (`SetCacheTtlRequest` / `CacheTtlResponse`),
so this brings the docs site into agreement with the spec and the backend.

Closes #70

## Test Checklist

- [x] \`npm run build\` passes
- [x] Verified page renders correctly locally (\`npm run dev\`)
- [x] Links are valid (no broken links)
- [x] Images load correctly
- [x] No regressions on other pages

Made with [Cursor](https://cursor.com)