### PR TITLE
docs(v1.5.0): audit log, download telemetry, CVE blast-radius, artifact versioning + RBAC (refs #54)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -78,6 +78,8 @@ export default defineConfig({
             { label: 'Health Scores', slug: 'docs/security/health-scores' },
             { label: 'Quality Gates', slug: 'docs/security/quality-gates' },
             { label: 'Security Policies', slug: 'docs/security/policies' },
+            { label: 'Audit Log', slug: 'docs/security/audit-log' },
+            { label: 'CVE Blast Radius', slug: 'docs/security/blast-radius' },
             { label: 'Artifact Signing', slug: 'docs/security/signing' },
             { label: 'Container Hardening', slug: 'docs/security/container-hardening' },
             { label: 'Security Testing', slug: 'docs/security/red-team' },
@@ -99,6 +101,7 @@ export default defineConfig({
             { label: 'Storage Backends', slug: 'docs/advanced/storage' },
             { label: 'Peer Replication', slug: 'docs/advanced/edge-nodes' },
             { label: 'WASM Plugins', slug: 'docs/advanced/plugins' },
+            { label: 'Artifact Versioning', slug: 'docs/advanced/versioning' },
             { label: 'Lifecycle Policies', slug: 'docs/advanced/lifecycle' },
             { label: 'Webhooks', items: [
               { label: 'Overview', slug: 'docs/advanced/webhooks' },
@@ -115,6 +118,7 @@ export default defineConfig({
             { label: 'Health Checks', slug: 'docs/monitoring/health-checks' },
             { label: 'Distributed Tracing', slug: 'docs/monitoring/tracing' },
             { label: 'Prometheus Metrics', slug: 'docs/monitoring/metrics' },
+            { label: 'Download Telemetry', slug: 'docs/monitoring/download-telemetry' },
           ],
         },
         {

--- a/src/content/docs/docs/advanced/versioning.mdx
+++ b/src/content/docs/docs/advanced/versioning.mdx
@@ -1,0 +1,138 @@
+---
+title: "Artifact Versioning"
+description: "First-class, immutable revision history for generic and ML-model artifacts"
+---
+
+Artifact Keeper provides opt-in first-class versioning for **generic** and **mlmodel** repositories. When enabled, re-uploading to an existing path appends a new immutable revision instead of overwriting the object in place — giving you a full, addressable history for artifacts that native package formats (npm, Maven, Docker, …) already version through their own coordinates.
+
+## When to Use It
+
+Native formats carry their version in the artifact coordinate (`my-lib@1.2.3`, `image:tag`), so they already have immutable, addressable history. Generic file storage and generic ML-model storage do not — historically a second upload to the same path overwrote the first. First-class versioning fills that gap for the two formats that need it:
+
+- **Generic** repositories — arbitrary build outputs, datasets, blobs
+- **ML-model (mlmodel)** repositories — model weights and artifacts stored via the generic ML-model endpoint
+
+Versioning applies **only** when the per-repository flag is enabled **and** the repository format is generic or mlmodel. Every other format, and every repository that has not opted in, keeps its existing single-copy semantics unchanged.
+
+## Enabling Versioning
+
+Versioning is controlled by a per-repository `versioning_enabled` flag, which **defaults to `false`**. Set it when creating or updating a generic or mlmodel repository:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "key": "models",
+        "format": "mlmodel",
+        "versioning_enabled": true
+      }' \
+  https://artifacts.example.com/api/v1/repositories
+```
+
+:::note
+The flag defaults off, so existing repositories and existing single-copy artifacts are completely unaffected until you opt in. Enabling it changes behavior only for future uploads to generic/mlmodel repositories.
+:::
+
+## Append-Revision vs Overwrite Semantics
+
+With versioning **disabled** (the default), a re-upload to an existing path overwrites in place — the previous bytes are replaced.
+
+With versioning **enabled** on a generic or mlmodel repository, a re-upload to an existing path **appends an immutable revision**:
+
+- Each upload is assigned a server-side, 1-based auto-increment `revision` number.
+- Previous revisions remain retrievable — nothing is overwritten.
+- The newest revision becomes the HEAD that plain (unversioned) requests resolve to.
+
+### Version Labels
+
+In addition to the numeric revision, an upload can carry a human-readable label via the `X-Artifact-Version` request header. The label is recorded alongside the revision and can be used later to select it:
+
+```bash
+curl -X PUT \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Artifact-Version: 2026.07-rc1" \
+  --data-binary @model.onnx \
+  https://artifacts.example.com/api/v1/repositories/models/artifacts/ranker/model.onnx
+```
+
+The upload response echoes the `revision` and `version_label` the upload landed at.
+
+## Listing Version History
+
+Retrieve the immutable revision history for a coordinate, newest-first:
+
+```bash
+GET /api/v1/repositories/{key}/versions/{path}
+```
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://artifacts.example.com/api/v1/repositories/models/versions/ranker/model.onnx"
+```
+
+```json
+{
+  "repository_key": "models",
+  "path": "ranker/model.onnx",
+  "items": [
+    {
+      "revision": 2,
+      "version_label": "2026.07-rc1",
+      "size_bytes": 104857600,
+      "checksum_sha256": "9f2b...c41a",
+      "content_type": "application/octet-stream",
+      "uploaded_by": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+      "created_at": "2026-07-10T18:42:07Z"
+    },
+    {
+      "revision": 1,
+      "version_label": null,
+      "size_bytes": 104857600,
+      "checksum_sha256": "1a2b...ff09",
+      "content_type": "application/octet-stream",
+      "uploaded_by": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+      "created_at": "2026-07-02T09:15:00Z"
+    }
+  ]
+}
+```
+
+Each `ArtifactVersionResponse` carries the `revision`, an optional `version_label` (omitted when the revision has no label), `size_bytes`, `checksum_sha256`, `content_type`, `uploaded_by`, and `created_at`. The `uploaded_by` field is always present (`null` for anonymous uploads) so the version-history UI can attribute every revision. The endpoint returns `404` when the coordinate has no recorded history.
+
+## Selecting a Version
+
+Download and metadata requests accept an optional `?version=<rev|label>` selector on versioning-enabled repositories:
+
+| `?version=` value | Resolves to |
+|-------------------|-------------|
+| omitted, empty, or `latest` | The HEAD (newest) revision |
+| a number, e.g. `1` | That exact revision number |
+| any other string, e.g. `2026.07-rc1` | The highest revision matching that `version_label` |
+
+```bash
+# Fetch revision 1 explicitly
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://artifacts.example.com/api/v1/repositories/models/artifacts/ranker/model.onnx?version=1"
+
+# Fetch by human label
+curl -H "Authorization: Bearer $TOKEN" \
+  "https://artifacts.example.com/api/v1/repositories/models/artifacts/ranker/model.onnx?version=2026.07-rc1"
+```
+
+The selector is ignored on repositories without versioning enabled, so it is safe to include unconditionally.
+
+## Relationship to Release Immutability
+
+First-class versioning is complementary to — and independent of — the release-immutability control. Release immutability prevents a released coordinate from being swapped (a delete-and-re-upload of different bytes to the same coordinate). Versioning changes what a re-upload *does* on opted-in generic/mlmodel repositories: it appends a new revision rather than mutating in place. Because versioning is gated behind the opt-in flag and applies only to generic/mlmodel formats, the release-immutability backstop and all other formats keep their existing behavior.
+
+## Version History in the Web UI
+
+Versioned artifacts surface a version-history view in the web console: each revision is listed newest-first with its revision number, label, size, checksum, uploader, and timestamp — backed by the same `GET /repositories/{key}/versions/{path}` endpoint. From there you can inspect or download any prior revision.
+
+## See Also
+
+- [More Formats](/docs/guides/more-formats) — generic file storage and generic ML-model endpoints
+- [Remote & Virtual Repositories](/docs/advanced/remote-virtual) — repository types and layout
+- [Staging & Promotion](/docs/advanced/staging-promotion) — promotion workflows and release gates
+- [Lifecycle Policies](/docs/advanced/lifecycle) — retention across artifact revisions

--- a/src/content/docs/docs/guides/more-formats.mdx
+++ b/src/content/docs/docs/guides/more-formats.mdx
@@ -107,6 +107,10 @@ For models not using HuggingFace format, use the generic ML model endpoint.
 **Endpoint Format:** `/mlmodel/{repo}`
 **Repository Key:** `mlmodel`
 
+:::tip
+Enable [artifact versioning](/docs/advanced/versioning) on an `mlmodel` repository to keep an immutable revision history of each model path — re-uploads append a new revision instead of overwriting, so you can retrieve and roll back to any prior version.
+:::
+
 Upload models via HTTP API:
 
 ```bash
@@ -412,6 +416,10 @@ Store any file type with custom metadata using the generic storage endpoint.
 
 **Endpoint Format:** `/generic/{repo}`
 **Repository Key:** `generic`
+
+:::tip
+Enable [artifact versioning](/docs/advanced/versioning) on a `generic` repository to append an immutable revision on every re-upload to a path (instead of overwriting), with a `?version=<rev|label>` selector for retrieving any prior revision.
+:::
 
 ### Upload Examples
 

--- a/src/content/docs/docs/monitoring/download-telemetry.mdx
+++ b/src/content/docs/docs/monitoring/download-telemetry.mdx
@@ -1,0 +1,119 @@
+---
+title: "Download Telemetry"
+description: "Per-download client IP and user attribution across all package formats in Artifact Keeper"
+---
+
+Artifact Keeper records the real client IP and authenticated user for every artifact download, across all 40+ package formats, into the `download_statistics` table. This gives administrators per-download attribution — "who pulled this, and from where" — that powers usage reporting, incident response, and the [CVE blast-radius](/docs/security/blast-radius) analysis.
+
+## What Gets Captured
+
+For each content-serving request, Artifact Keeper records:
+
+- **Client IP** — the resolved real client address (see [Real-Client-IP Resolution](#real-client-ip-resolution) below)
+- **User** — the authenticated principal, or `null` for anonymous downloads
+- **User agent** — the request's `User-Agent` header, when present
+- **Timestamp** — when the download was served
+
+Recording is best-effort and never blocks or rejects a download: an anonymous request records a `null` user, and an unresolvable client records a `null` IP — never a sentinel such as `0.0.0.0`.
+
+### Coverage
+
+Attribution covers **every** content-serving path, not just the native package-manager routes. In this release, recording was extended to close the remaining gaps:
+
+- The generic `/artifacts/{path}` download branch
+- Virtual-repository member-local download branches
+- Presigned-redirect download paths (object-storage backends)
+
+The result is uniform per-download attribution regardless of format or storage backend.
+
+## Real-Client-IP Resolution
+
+When Artifact Keeper runs behind a reverse proxy or load balancer, the socket peer is the proxy, not the end client — so the real client IP must come from the `X-Forwarded-For` (XFF) header. Trusting that header blindly would let any caller spoof attribution, so resolution is gated on a trusted-proxy allowlist:
+
+- The **socket peer address is authoritative** by default.
+- `X-Forwarded-For` is believed **only when the peer is inside a configured trusted-proxy CIDR range**.
+- If nothing resolves, the IP is recorded as `null`.
+
+The trusted-proxy ranges are configured with the `RATE_LIMIT_TRUSTED_PROXY_CIDRS` environment variable (the same allowlist the rate limiter uses). It is empty by default, which means XFF is ignored and the socket peer is always used.
+
+```bash
+# Trust XFF only from your ingress / load-balancer subnets
+RATE_LIMIT_TRUSTED_PROXY_CIDRS="10.0.0.0/8,192.168.0.0/16"
+```
+
+:::caution
+If you terminate connections behind a proxy but leave `RATE_LIMIT_TRUSTED_PROXY_CIDRS` empty, every download will be attributed to the proxy's IP. Set it to the CIDR ranges of your trusted proxies so the real client IP is recorded. Conversely, listing an untrusted range here would let clients in that range spoof their attributed IP via XFF — only list infrastructure you control.
+:::
+
+This resolution rule also closed a trusted-proxy XFF-spoofing gap on the download path, so an untrusted peer can no longer steer its recorded IP through a forged `X-Forwarded-For` header.
+
+## Querying Downloads
+
+Download telemetry is queried through admin-only endpoints. They require an administrator bearer token; download attribution is sensitive, so non-admin callers receive `403 Forbidden`.
+
+### List Downloads
+
+```bash
+GET /api/v1/admin/downloads
+```
+
+All filters are optional and combine with AND semantics:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `artifact_id` | UUID | Downloads of one artifact |
+| `user_id` | UUID | Downloads by one user |
+| `ip` | string | Downloads from one client IP (exact match) |
+| `from` | RFC 3339 | Inclusive lower bound on `downloaded_at` |
+| `to` | RFC 3339 | Inclusive upper bound on `downloaded_at` |
+| `page` | integer | 1-based page index (default `1`) |
+| `per_page` | integer | Page size (default `20`, max `100`) |
+
+Events are returned newest-first.
+
+```json
+{
+  "downloads": [
+    {
+      "artifact_id": "1122aabb-ccdd-eeff-0011-223344556677",
+      "user_id": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+      "username": "alice",
+      "ip_address": "203.0.113.9",
+      "user_agent": "npm/10.2.0 node/v20.11.0",
+      "downloaded_at": "2026-07-10T18:42:07Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "per_page": 20
+}
+```
+
+`username` is populated when the download was authenticated and the user still exists; `ip_address` is `null` for legacy rows and unresolvable clients.
+
+### Downloads by IP
+
+"What did this network location pull?" The IP is a path parameter and must be a valid address (otherwise `400`):
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "https://artifacts.example.com/api/v1/admin/downloads/by-ip/203.0.113.9"
+```
+
+### Downloads by User
+
+"What did this user pull?" The user id is a path parameter:
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "https://artifacts.example.com/api/v1/admin/downloads/by-user/9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d"
+```
+
+Both scoped endpoints accept the same `artifact_id`, `from`, `to`, `page`, and `per_page` filters as `GET /downloads` and return the same response shape.
+
+## See Also
+
+- [CVE Blast Radius](/docs/security/blast-radius) — join CVE findings to the users and IPs that downloaded a vulnerable artifact
+- [Audit Log](/docs/security/audit-log) — the security-event audit trail, including download events
+- [Prometheus Metrics](/docs/monitoring/metrics) — aggregate download and usage metrics
+- [Reverse Proxy & TLS](/docs/deployment/reverse-proxy) — running Artifact Keeper behind a proxy

--- a/src/content/docs/docs/monitoring/metrics.mdx
+++ b/src/content/docs/docs/monitoring/metrics.mdx
@@ -229,6 +229,7 @@ Tune the `for` duration and threshold values to match your environment. A 5% err
 
 ## See Also
 
+- [Download Telemetry](/docs/monitoring/download-telemetry) -- Per-download client IP and user attribution
 - [Helm Chart Deployment](/docs/deployment/helm) -- ServiceMonitor setup and production deployment
 - [Backup & Recovery](/docs/advanced/backup) -- Backup metrics and alerting
 - [Vulnerability Scanning](/docs/security/scanning) -- Security scan metrics and monitoring

--- a/src/content/docs/docs/security/audit-log.mdx
+++ b/src/content/docs/docs/security/audit-log.mdx
@@ -1,0 +1,110 @@
+---
+title: "Audit Log"
+description: "Query the functional audit trail of security-relevant events in Artifact Keeper"
+---
+
+Artifact Keeper records security-relevant events into a functional audit trail and exposes them through an admin-only query API and the admin web UI. The audit log answers "who did what, to which resource, and when" — including the denials that were blocked before they could take effect.
+
+## What Gets Recorded
+
+Every audit event captures the acting user, an action string, the affected resource, the client IP, a request correlation ID, and a timestamp. The events currently recorded include:
+
+- **Artifact operations** — `ARTIFACT_UPLOADED`, `ARTIFACT_DOWNLOADED`, `ARTIFACT_DELETED`, `ARTIFACT_METADATA_UPDATED`
+- **User and role management** — `USER_CREATED`, `USER_UPDATED`, `USER_DELETED`, `USER_DISABLED`, `ROLE_ASSIGNED`, `ROLE_REVOKED`
+- **Repository lifecycle** — `REPOSITORY_CREATED`, `REPOSITORY_UPDATED`, `REPOSITORY_DELETED`, `REPOSITORY_PERMISSION_CHANGED`
+- **Authentication** — `LOGIN`, `LOGOUT`, `LOGIN_FAILED`, `PASSWORD_CHANGED`, `API_TOKEN_CREATED`, `API_TOKEN_REVOKED`, `TOTP_ENABLED`, `TOTP_DISABLED`, `SESSIONS_INVALIDATED`
+- **Authorization denials** — `PERMISSION_DENIED`, emitted whenever a caller is rejected for lacking the required permission (see [Security Policies](/docs/security/policies) for the tightened RBAC rules that raise these)
+- **Platform operations** — backups and restores, peer registration and sync, plugin lifecycle, setting changes, SBOM generation, and more
+
+:::note
+`PERMISSION_DENIED` events give you a record of *attempted* access that was blocked — not just successful actions. This is the signal to watch for probing behavior or misconfigured automation.
+:::
+
+## Querying the Audit Log
+
+The audit log is queried through a single admin-only endpoint. It requires an administrator bearer token; non-admin callers receive `403 Forbidden`.
+
+```bash
+GET /api/v1/admin/audit
+```
+
+### Filters
+
+All filters are optional and combine with AND semantics:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `user_id` | UUID | Filter by acting/subject user |
+| `action` | string | Exact action string, e.g. `ARTIFACT_DOWNLOADED` |
+| `resource_type` | string | e.g. `user`, `repository`, `artifact` |
+| `resource_id` | UUID | The affected resource id |
+| `correlation_id` | string | Exact request correlation / trace id |
+| `from` | RFC 3339 | Inclusive lower time bound |
+| `to` | RFC 3339 | Inclusive upper time bound |
+| `page` | integer | 1-based page index (default `1`) |
+| `per_page` | integer | Page size (default `50`, max `200`) |
+
+Events are returned newest-first.
+
+```bash
+# Every artifact deletion in a time window, most recent first
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "https://artifacts.example.com/api/v1/admin/audit?action=ARTIFACT_DELETED&from=2026-07-01T00:00:00Z&per_page=100"
+```
+
+### Response
+
+```json
+{
+  "items": [
+    {
+      "id": "5c1f2e8a-1b3c-4d5e-8f90-1a2b3c4d5e6f",
+      "user_id": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+      "actor_username": "ci-bot",
+      "action": "ARTIFACT_DELETED",
+      "resource_type": "artifact",
+      "resource_id": "1122aabb-ccdd-eeff-0011-223344556677",
+      "details": { "path": "builds/v1.0.0/output.tar.gz" },
+      "ip_address": "203.0.113.9",
+      "correlation_id": "b7c3f1a2-9d4e-4c5b-8a1f-0e2d3c4b5a69",
+      "created_at": "2026-07-10T18:42:07Z"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "per_page": 50
+}
+```
+
+### Actor Username Resolution
+
+Each row embeds `actor_username`, resolved server-side so clients do not have to make a second lookup per event. It is `null` in two cases:
+
+- The action was performed by a **system/non-user actor** (e.g. a scheduled maintenance task).
+- The acting user has since been **deleted** — the historical `user_id` is retained, but the name can no longer be resolved.
+
+The `correlation_id` is a string (not a UUID): it carries the request's `X-Correlation-ID` or W3C trace id, which lets you tie an audit event back to the specific request across your logs and traces.
+
+## Retention
+
+Audit events are retained according to the `audit_retention_days` system setting (default **90 days**). Retention is enforced when the audit cleanup task runs:
+
+```bash
+POST /api/v1/admin/cleanup
+Content-Type: application/json
+
+{ "cleanup_audit_logs": true }
+```
+
+Events older than the configured retention window are deleted. Increase `audit_retention_days` through the admin settings if your compliance program requires a longer trail, and export events on a schedule if you need retention beyond what you keep in the database.
+
+## Admin Web UI
+
+The audit trail is also browsable from the admin area of the web console. The UI wraps the same query endpoint with a filterable, paginated table — filter by action, actor, resource, and time range, and drill into individual events to see the embedded details and correlation id. Because the underlying endpoint is admin-only, the audit view is visible only to administrators.
+
+## See Also
+
+- [Security Policies](/docs/security/policies) — the RBAC rules whose denials emit `PERMISSION_DENIED` audit events
+- [Download Telemetry](/docs/monitoring/download-telemetry) — per-download IP and user attribution
+- [CVE Blast Radius](/docs/security/blast-radius) — join CVE findings to the users and IPs that downloaded an affected artifact
+- [Authentication & RBAC](/docs/advanced/auth) — users, roles, and permissions

--- a/src/content/docs/docs/security/blast-radius.mdx
+++ b/src/content/docs/docs/security/blast-radius.mdx
@@ -1,0 +1,124 @@
+---
+title: "CVE Blast Radius"
+description: "Determine who is exposed by a vulnerability by joining CVE findings to download attribution"
+---
+
+When a new CVE lands, the first question is "who is exposed?" Artifact Keeper's blast-radius analysis answers it by joining vulnerability scan findings to the [per-download attribution](/docs/monitoring/download-telemetry) collected across the registry: it reports the users and client IPs that actually downloaded an affected artifact, plus a bounded classification of how widely each affected repository is reachable.
+
+## What Blast Radius Answers
+
+Given a CVE id — or a single artifact — the report tells you:
+
+- **Which artifacts** carry the finding and have been downloaded.
+- **Which users and IPs** downloaded them (with per-downloader counts and first/last download times).
+- **How exposed** each affected repository is, via a per-repository access-scope classification.
+
+:::note
+This analysis reports who **downloaded** a vulnerable artifact. Full enumeration of every principal who *could* access it but has not downloaded it (expanding all roles and groups) is deferred to a follow-up phase; the per-repository `access_scope` gives you the exposure signal in the meantime.
+:::
+
+## Endpoints
+
+Both endpoints are admin-only (download attribution is sensitive) and require an administrator bearer token; non-admin callers receive `403 Forbidden`.
+
+### Blast Radius for a CVE
+
+```bash
+GET /api/v1/admin/security/cve/{cve_id}/blast-radius
+```
+
+`cve_id` is matched exactly against the canonical id stored by the scanners (e.g. `CVE-2021-44228`).
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "https://artifacts.example.com/api/v1/admin/security/cve/CVE-2021-44228/blast-radius"
+```
+
+### Blast Radius for an Artifact
+
+```bash
+GET /api/v1/admin/security/artifact/{artifact_id}/blast-radius
+```
+
+Reports who downloaded one specific artifact, regardless of which CVE flagged it.
+
+### Query Parameters
+
+Both endpoints accept the same optional filters, which scope the downloader analysis to a time window and paginate the downloaders list:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | RFC 3339 | Inclusive lower bound on `downloaded_at` |
+| `to` | RFC 3339 | Inclusive upper bound on `downloaded_at` |
+| `page` | integer | 1-based page over the downloaders list (default `1`) |
+| `per_page` | integer | Downloaders per page (default `20`, max `100`) |
+
+## Response Shape
+
+```json
+{
+  "target": { "kind": "cve", "value": "CVE-2021-44228" },
+  "summary": {
+    "affected_artifact_count": 3,
+    "affected_repo_count": 2,
+    "downloader_user_count": 5,
+    "anonymous_download_present": true,
+    "distinct_ip_count": 11,
+    "total_download_count": 27
+  },
+  "affected_repos": [
+    {
+      "repository_id": "aa11bb22-cc33-dd44-ee55-ff6677889900",
+      "repository_key": "public-libs",
+      "is_public": true,
+      "access_scope": "public"
+    }
+  ],
+  "downloaders": [
+    {
+      "user_id": "9a8b7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+      "username": "alice",
+      "download_count": 4,
+      "distinct_ip_count": 2,
+      "first_download": "2026-07-02T09:15:00Z",
+      "last_download": "2026-07-10T18:42:07Z",
+      "ip_addresses": ["203.0.113.9", "198.51.100.7"]
+    }
+  ],
+  "total_downloaders": 6,
+  "page": 1,
+  "per_page": 20
+}
+```
+
+Notes on the shape:
+
+- `summary` counts are scoped to the requested download window. `anonymous_download_present` flags whether any download in the window was unauthenticated.
+- `downloaders` collapses events per principal; the anonymous bucket appears as a single row with `user_id: null`. `username` is `null` for anonymous or deleted users. `total_downloaders` is the pagination total (the anonymous bucket counts as one).
+- `ip_addresses` is a **bounded sample** (up to 50 distinct IPs per downloader); `distinct_ip_count` remains the exact total.
+- `affected_repos` lists **every** repository holding an affected artifact — independent of the download window, so you see exposure even before the first pull. The list is bounded (up to 200 entries) while `summary.affected_repo_count` remains the true total.
+
+## Exposure Classes
+
+Each affected repository is classified by how widely it is reachable:
+
+| `access_scope` | Meaning |
+|----------------|---------|
+| `public` | Anyone, including anonymous clients, can read the repository. |
+| `restricted_acl` | Private, with at least one explicit ACL entry granting specific users or groups access. |
+| `restricted_roles` | Private with no repository ACL entries; access flows only through role assignments and admin rights. |
+
+### Public Repositories: Bounded "Everyone Exposed"
+
+A public repository is, by definition, readable by an unbounded and unknowable population — every anonymous client on the network. Rather than attempt to enumerate that population, blast radius reports the bounded, factual signals: it flags the repository as `access_scope: public` (so you can see at a glance that "this is a public repo — everyone is potentially exposed"), and it still lists the concrete users and IPs that *did* download the artifact, with `anonymous_download_present` set when unauthenticated pulls occurred. You get an honest exposure picture without a misleadingly precise "affected users" list that could never be complete.
+
+## Admin Web UI
+
+Blast radius is surfaced in the admin security area of the web console. From a CVE finding you can open its blast-radius view to see the summary counts, the affected repositories with their exposure classes highlighted, and the paginated downloaders table with per-user IP samples. As with the API, the view is admin-only.
+
+## See Also
+
+- [Download Telemetry](/docs/monitoring/download-telemetry) — the per-download IP and user attribution this analysis joins against
+- [Vulnerability Scanning](/docs/security/scanning) — how CVE findings are produced
+- [Audit Log](/docs/security/audit-log) — the security-event audit trail
+- [Security Policies](/docs/security/policies) — block vulnerable artifacts before they spread

--- a/src/content/docs/docs/security/policies.mdx
+++ b/src/content/docs/docs/security/policies.mdx
@@ -16,6 +16,38 @@ Security policies provide automated governance over which artifacts can be deplo
 - **Allow**: Permit without restrictions
 - **Quarantine**: Mark artifact as quarantined for review
 
+## Repository Access Control (RBAC)
+
+Beyond vulnerability policies, Artifact Keeper enforces role-based access control on repository operations. Recent hardening tightened how write, delete, and admin-only actions are authorized.
+
+### Action-Specific Write/Delete Permissions
+
+The generic-REST and OCI artifact paths now enforce **action-specific** permissions rather than collapsing read, write, and delete into a single predicate. A grantee with read-only access can no longer write or delete artifacts — read, write, and delete are evaluated independently.
+
+:::caution
+If your automation previously relied on a read-only grant being able to push or delete (an over-broad predicate), it will now be rejected. Grant the specific write/delete permission the workflow needs.
+:::
+
+### Admin / Repo-Admin Gated Operations
+
+The following operations are gated to **admin** or **repo-admin** and are no longer available to ordinary write grantees:
+
+- **Dependency-Track integration**
+- **SBOM CVE-status updates**
+- **Webhook creation**
+- **Scan triggering**
+- **Cache invalidation**
+
+Promotion and peer-replication paths are unaffected by this change and keep their existing authorization.
+
+### Denials Are Audited
+
+Every authorization denial from these checks emits a `PERMISSION_DENIED` event to the [audit log](/docs/security/audit-log). This gives you a record of *attempted* privileged actions that were blocked — the signal to watch for misconfigured automation or probing. Query them with:
+
+```bash
+GET /api/v1/admin/audit?action=PERMISSION_DENIED
+```
+
 ## Policy Configuration
 
 ### Policy Definition
@@ -623,6 +655,7 @@ cache:
 
 ## See Also
 
+- [Audit Log](/docs/security/audit-log) - Query `PERMISSION_DENIED` and other security events
 - [SBOM & License Compliance](/docs/security/sbom) - Software Bill of Materials and Dependency-Track integration
 - [Vulnerability Scanning](/docs/security/scanning) - Configure artifact security scanning
 - [Artifact Signing](/docs/security/signing) - Verify artifact authenticity

--- a/src/content/docs/docs/security/scanning.mdx
+++ b/src/content/docs/docs/security/scanning.mdx
@@ -555,6 +555,7 @@ grype db update
 
 ## See Also
 
+- [CVE Blast Radius](/docs/security/blast-radius) - Find who is exposed by a CVE via download attribution
 - [SBOM & License Compliance](/docs/security/sbom) - Software Bill of Materials and Dependency-Track integration
 - [Security Policies](/docs/security/policies) - Configure policies to block vulnerable artifacts
 - [Artifact Signing](/docs/security/signing) - Verify artifact integrity and authenticity


### PR DESCRIPTION
Documents the four net-new v1.5.0 features that shipped with zero docs, plus an RBAC update. Every endpoint path, request/response field, and behavior below was verified against the artifact-keeper backend source (`backend/src/api/handlers/*.rs`, `routes.rs`, and the `[1.5.0]` CHANGELOG) — not just the changelog prose.

### New pages
- **`src/content/docs/docs/security/audit-log.mdx`** — functional audit log (#2366/#2392). Events recorded, `GET /api/v1/admin/audit` filters + pagination, server-embedded `actor_username` (null for deleted/system actors), correlation-id filter, retention (`audit_retention_days`, default 90), admin web UI. Verified in `admin.rs` + `audit_service.rs`.
- **`src/content/docs/docs/monitoring/download-telemetry.mdx`** — per-download IP + user telemetry (#2365/#2394/#2398). `download_statistics` capture, XFF real-client-IP gated by `RATE_LIMIT_TRUSTED_PROXY_CIDRS`, `GET /api/v1/admin/downloads` (+ `/by-ip/{ip}`, `/by-user/{user_id}`), coverage incl. generic `/artifacts/{path}`, virtual member-local, and presigned-redirect paths. Verified in `admin.rs` + `middleware/download_telemetry.rs`.
- **`src/content/docs/docs/security/blast-radius.mdx`** — CVE blast-radius (#2364). `GET /api/v1/admin/security/cve/{cve_id}/blast-radius` and `/artifact/{artifact_id}/blast-radius`, exposure classes (`public`/`restricted_acl`/`restricted_roles`), bounded "public repo — everyone exposed" behavior, admin web UI. Verified in `admin_security.rs`.
- **`src/content/docs/docs/advanced/versioning.mdx`** — first-class versioning for generic & mlmodel (#2367). Per-repo `versioning_enabled` (default off), append-revision vs overwrite, `GET /api/v1/repositories/{key}/versions/{path}`, `?version=<rev|label>` selector, `ArtifactVersionResponse`, relationship to release-immutability, version-history UI. Verified in `repositories.rs` + `artifact_service.rs`.

### Updated
- **`src/content/docs/docs/security/policies.mdx`** — RBAC hardening (#2321): action-specific write/delete on generic-REST + OCI paths; dependency-track, SBOM CVE-status, webhook creation, scan triggering, and cache invalidation now admin/repo-admin gated; denials emit a `PERMISSION_DENIED` audit event (cross-linked to audit-log).

### Wiring
- Registered all four pages in `astro.config.mjs` sidebar (Security / Monitoring / Advanced).
- Cross-links added: scanning → blast-radius, metrics → download-telemetry, more-formats (generic + mlmodel) → versioning, policies → audit-log.
- `npm ci` + `npm run build` pass clean (only pre-existing `wit`/`promql` syntax-highlight warnings in unrelated files).

Refs umbrella issue #54.