### PR TITLE
docs(reference): consolidate + refresh environment/config reference (supersedes #55/#50/#53, Closes #63 #73)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -27,6 +27,7 @@ export default defineConfig({
             { label: 'Welcome', slug: 'docs' },
             { label: 'Architecture', slug: 'docs/getting-started/architecture' },
             { label: 'Quickstart', slug: 'docs/getting-started/quickstart' },
+            { label: 'Quickstart Installer', slug: 'docs/getting-started/quickstart-installer' },
             { label: 'Installation', slug: 'docs/getting-started/installation' },
             { label: 'Configuration', slug: 'docs/getting-started/configuration' },
             { label: 'Support Policy', slug: 'docs/getting-started/support-policy' },
@@ -72,6 +73,7 @@ export default defineConfig({
         {
           label: 'Security',
           items: [
+            { label: 'Authentication Security', slug: 'docs/security/authentication' },
             { label: 'Vulnerability Scanning', slug: 'docs/security/scanning' },
             { label: 'OpenSCAP Compliance', slug: 'docs/security/openscap' },
             { label: 'SBOM & Dependency-Track', slug: 'docs/security/sbom' },

--- a/src/content/docs/docs/advanced/storage.mdx
+++ b/src/content/docs/docs/advanced/storage.mdx
@@ -620,13 +620,14 @@ curl -X POST https://registry.example.com/api/v1/admin/cleanup \
 
 ### Scheduled Cleanup
 
-Configure automatic garbage collection:
+Storage garbage collection runs on a cron schedule. Only two environment variables control it:
 
 ```bash
-GC_ENABLED=true
-GC_SCHEDULE="0 2 * * *"  # Daily at 2 AM
-GC_RETENTION_DAYS=90     # Keep artifacts for 90 days
+GC_SCHEDULE="0 0 * * * *"  # 6-field cron (sec min hour day month weekday); default hourly
+BLOB_GC_ENABLED=true       # Opt in to actually deleting blobs (default: false = dry-run pass)
 ```
+
+There is no `GC_ENABLED` or `GC_RETENTION_DAYS` variable. **Retention is not configured here** — artifact retention is governed by [lifecycle policies](/docs/advanced/lifecycle), created and managed via the Admin API or the web UI. By default `BLOB_GC_ENABLED` is `false`, so the scheduled pass dry-runs (logs what it would remove) until an operator explicitly opts in to live blob deletion.
 
 ### What Gets Cleaned
 
@@ -637,13 +638,13 @@ GC_RETENTION_DAYS=90     # Keep artifacts for 90 days
 
 ### Dry Run Mode
 
-Always test with dry run first:
+The scheduled pass is dry-run by default. Leaving `BLOB_GC_ENABLED` unset (or `false`) logs what would be deleted without actually removing anything:
 
 ```bash
-GC_DRY_RUN=true
+BLOB_GC_ENABLED=false   # default — dry-run only
 ```
 
-This logs what would be deleted without actually removing anything.
+Set `BLOB_GC_ENABLED=true` once you have reviewed the logged candidates and are ready for live blob deletion.
 
 ## Storage Migration
 

--- a/src/content/docs/docs/getting-started/quickstart-installer.mdx
+++ b/src/content/docs/docs/getting-started/quickstart-installer.mdx
@@ -1,0 +1,159 @@
+---
+title: "Quickstart Installer"
+description: "One-command setup for Artifact Keeper using the automated installer script"
+---
+
+The quickstart installer detects your container runtime, generates secure credentials, downloads the compose file, and starts the full stack with a single command.
+
+## Usage
+
+```bash
+curl -fsSL https://get.artifactkeeper.com | bash
+```
+
+This is equivalent to running the installer script directly from the repository:
+
+```bash
+bash scripts/install.sh
+```
+
+## What the Installer Does
+
+1. **Detects your container runtime**: Docker with Compose V2, Docker with docker-compose, Podman with podman-compose, or Podman with Compose. The installer will exit with an error if no supported runtime is found.
+
+2. **Checks port availability**: Verifies that ports 80 and 443 (or your configured ports) are not already in use.
+
+3. **Generates secure credentials**: Creates random values for `JWT_SECRET`, the search master key, the PostgreSQL password, and (if not provided) the admin password. Credentials are generated using `openssl rand` when available, falling back to `/dev/urandom`.
+
+4. **Creates a project directory**: Defaults to `./artifact-keeper` in the current directory. The installer will not overwrite an existing installation.
+
+5. **Downloads configuration files**: Pulls the `docker-compose.yml`, Caddyfile, database init script, and supporting files from the main branch of the repository.
+
+6. **Writes a `.env` file**: Stores all generated credentials and settings. This file is the single source of configuration for the stack.
+
+7. **Pulls images and starts services**: Runs `docker compose pull` followed by `docker compose up -d`.
+
+8. **Waits for readiness**: Polls the health endpoint for up to 2 minutes. Once the backend responds, opens the web UI in your browser (on systems that support it).
+
+## Services Started
+
+The installer brings up the full stack:
+
+| Service | Description |
+|---------|-------------|
+| **Backend** | Rust API server with 45+ format handlers |
+| **Web UI** | Next.js frontend |
+| **Caddy** | Reverse proxy (HTTP + HTTPS with automatic TLS) |
+| **PostgreSQL 16** | Metadata storage |
+| **OpenSearch** | Full-text search |
+| **Trivy** | Vulnerability scanning |
+| **OpenSCAP** | Compliance scanning |
+| **Dependency-Track** | SBOM analysis and vulnerability management |
+
+In minimal mode (`AK_MINIMAL=1`), the scanners (Trivy, OpenSCAP, Dependency-Track) are skipped to reduce resource usage.
+
+## Configuration Options
+
+All options are set as environment variables before running the installer.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INSTALL_DIR` | `./artifact-keeper` | Directory where the project files are created |
+| `AK_VERSION` | `latest` | Version to install (omit the `v` prefix) |
+| `AK_HTTP_PORT` | `80` | HTTP port |
+| `AK_HTTPS_PORT` | `443` | HTTPS port |
+| `AK_ADMIN_PASSWORD` | auto-generated | Admin password. When omitted, a random 24-character password is generated and saved to `.env`. |
+| `AK_SKIP_START` | `0` | Set to `1` to generate files without starting the stack |
+| `AK_MINIMAL` | `0` | Set to `1` to skip scanners (lower resource usage) |
+
+### Examples
+
+Install with custom ports:
+
+```bash
+AK_HTTP_PORT=8080 AK_HTTPS_PORT=8443 curl -fsSL https://get.artifactkeeper.com | bash
+```
+
+Install a specific version:
+
+```bash
+AK_VERSION=1.1.0 curl -fsSL https://get.artifactkeeper.com | bash
+```
+
+Install in minimal mode (no scanners):
+
+```bash
+AK_MINIMAL=1 curl -fsSL https://get.artifactkeeper.com | bash
+```
+
+Generate files without starting:
+
+```bash
+AK_SKIP_START=1 curl -fsSL https://get.artifactkeeper.com | bash
+cd artifact-keeper
+# Review .env and docker-compose.yml, then:
+docker compose up -d
+```
+
+Set a specific admin password:
+
+```bash
+AK_ADMIN_PASSWORD=my-secure-password curl -fsSL https://get.artifactkeeper.com | bash
+```
+
+## Requirements
+
+- **Container runtime**: Docker 20.10+ with Compose V2, or Podman 4+ with podman-compose
+- **RAM**: 2 GB minimum, 4 GB recommended with scanners enabled
+- **Ports**: 80 and 443 available (configurable via `AK_HTTP_PORT` and `AK_HTTPS_PORT`)
+
+## After Installation
+
+Once the installer completes, it prints the connection details:
+
+```
+==> Artifact Keeper is running!
+
+  Web UI:    http://localhost:80
+  API:       http://localhost:80/api/v1
+  Swagger:   http://localhost:80/swagger-ui
+
+  Username:  admin
+  Password:  <generated-password>
+```
+
+### Managing the Stack
+
+```bash
+cd artifact-keeper         # or your custom INSTALL_DIR
+docker compose ps          # check status
+docker compose logs -f     # follow logs
+docker compose down        # stop all services
+docker compose up -d       # start all services
+```
+
+### Upgrading
+
+To upgrade to a newer version, update `ARTIFACT_KEEPER_VERSION` in the `.env` file and pull new images:
+
+```bash
+cd artifact-keeper
+# Edit .env: set ARTIFACT_KEEPER_VERSION=1.2.0
+docker compose pull
+docker compose up -d
+```
+
+### Uninstalling
+
+```bash
+cd artifact-keeper
+docker compose down -v     # stop and remove volumes
+cd ..
+rm -rf artifact-keeper     # remove all files
+```
+
+## Next Steps
+
+- [Quickstart Guide](/docs/getting-started/quickstart) - Create repositories and push your first artifact
+- [Configuration Reference](/docs/getting-started/configuration) - All available environment variables
+- [Docker Deployment](/docs/deployment/docker) - Production Docker Compose setup

--- a/src/content/docs/docs/getting-started/quickstart.mdx
+++ b/src/content/docs/docs/getting-started/quickstart.mdx
@@ -15,6 +15,14 @@ Get Artifact Keeper up and running in minutes using Docker Compose.
 
 - Docker and Docker Compose (or Podman with `podman-compose`) installed
 
+:::tip[Quickstart Installer]
+For a fully automated setup, use the [quickstart installer](/docs/getting-started/quickstart-installer) instead. It generates secure credentials, downloads all files, and starts the stack with a single command:
+
+```bash
+curl -fsSL https://get.artifactkeeper.com | bash
+```
+:::
+
 ## Quick Start
 
 1. **Download and start**:
@@ -142,26 +150,26 @@ Or use the Web UI: navigate to **Repositories** and click **Create Repository**.
 <distributionManagement>
   <repository>
     <id>artifact-keeper</id>
-    <url>http://localhost:30080/api/v1/maven/my-maven-repo</url>
+    <url>http://localhost:30080/maven/my-maven-repo</url>
   </repository>
 </distributionManagement>
 ```
 
 **npm** (using `.npmrc`):
 ```
-registry=http://localhost:30080/api/v1/npm/my-npm-repo/
-//localhost:30080/api/v1/npm/my-npm-repo/:_authToken=YOUR_TOKEN
+registry=http://localhost:30080/npm/my-npm-repo/
+//localhost:30080/npm/my-npm-repo/:_authToken=YOUR_TOKEN
 ```
 
-**Docker**:
+**Docker** (OCI registry mounted at `/v2`; the client adds the `/v2/` prefix automatically):
 ```bash
-docker tag myimage:latest localhost:30080/api/v1/docker/my-docker-repo/myimage:latest
-docker push localhost:30080/api/v1/docker/my-docker-repo/myimage:latest
+docker tag myimage:latest localhost:30080/my-docker-repo/myimage:latest
+docker push localhost:30080/my-docker-repo/myimage:latest
 ```
 
 **PyPI** (using twine):
 ```bash
-twine upload --repository-url http://localhost:30080/api/v1/pypi/my-pypi-repo/ \
+twine upload --repository-url http://localhost:30080/pypi/my-pypi-repo/ \
   -u admin -p admin dist/*
 ```
 

--- a/src/content/docs/docs/monitoring/tracing.mdx
+++ b/src/content/docs/docs/monitoring/tracing.mdx
@@ -3,7 +3,7 @@ title: "Distributed Tracing"
 description: "Configure OpenTelemetry distributed tracing in Artifact Keeper for full request visibility across services"
 ---
 
-Artifact Keeper supports opt-in OpenTelemetry distributed tracing. When enabled, spans are exported via OTLP gRPC to any compatible collector such as Jaeger, Grafana Tempo, Datadog, or AWS X-Ray. When disabled (the default), behavior is identical to stdout-only logging with zero overhead.
+Artifact Keeper supports opt-in OpenTelemetry distributed tracing. When enabled, spans are exported via OTLP gRPC or HTTP to any compatible collector such as Jaeger, Grafana Tempo, Datadog, SigNoz or AWS X-Ray. When disabled (the default), behavior is identical to stdout-only logging with zero overhead.
 
 ## Configuration
 
@@ -12,6 +12,7 @@ Tracing is controlled entirely through environment variables. No code changes or
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | _(unset)_ | OTLP collector endpoint (e.g., `http://jaeger:4317`). When unset, tracing exports are disabled. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `grpc` | Type of exporter for [OpenTelemetry](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) (either `grpc` or `http/protobuf`) |
 | `OTEL_SERVICE_NAME` | No | `artifact-keeper` | Service name that appears in traces. |
 | `RUST_LOG` | No | `info,sqlx::query=info` | Log and trace filter directive. The default includes `sqlx::query=info` which enables database query spans. |
 

--- a/src/content/docs/docs/reference/environment.mdx
+++ b/src/content/docs/docs/reference/environment.mdx
@@ -13,8 +13,7 @@ Configure Artifact Keeper using environment variables. This page provides a comp
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `PORT` | No | `8080` | HTTP server port |
-| `HOST` | No | `0.0.0.0` | HTTP server bind address |
+| `BIND_ADDRESS` | No | `0.0.0.0:8080` | HTTP server bind address in `host:port` form. (There is no separate `PORT`/`HOST` variable.) |
 | `RUST_LOG` | No | `info` | Log level (trace, debug, info, warn, error) |
 | `LOG_FORMAT` | No | `json` | Log format (json, pretty, compact) |
 | `ENVIRONMENT` | No | `production` | Runtime environment. Set to `development` to disable the `Secure` flag on auth cookies, allowing cookie-based auth over plain HTTP. See [Reverse Proxy & TLS](/docs/deployment/reverse-proxy). |
@@ -26,24 +25,59 @@ Configure Artifact Keeper using environment variables. This page provides a comp
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `DATABASE_URL` | Yes | - | PostgreSQL connection string (postgres://user:pass@host:port/db) |
-| `DB_POOL_SIZE` | No | `20` | Maximum database connection pool size |
-| `DB_TIMEOUT_SECONDS` | No | `30` | Database connection timeout |
+| `DATABASE_MAX_CONNECTIONS` | No | `50` | Maximum open connections in the pool. Increase for higher concurrency, decrease for databases with restricted connection budgets (shared RDS, PgBouncer). |
+| `DATABASE_MIN_CONNECTIONS` | No | `5` | Minimum idle connections kept warm. Set to 0 to allow the pool to scale down completely. |
+| `DATABASE_ACQUIRE_TIMEOUT_SECS` | No | `5` | Timeout in seconds for acquiring a connection from the pool before returning an error |
+| `DATABASE_IDLE_TIMEOUT_SECS` | No | `600` | Close connections idle longer than this many seconds (10 minutes) |
+| `DATABASE_MAX_LIFETIME_SECS` | No | `1800` | Recycle connections older than this, even if healthy (30 minutes). Useful behind TCP load balancers with an idle disconnect. |
 | `DB_SSL_MODE` | No | `prefer` | PostgreSQL SSL mode (disable, allow, prefer, require) |
+| `SKIP_MIGRATIONS` | No | `false` | Skip automatic database migrations on startup. Use when migrations are applied out-of-band (e.g., via a CI job or init container). |
 
 ## Authentication
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `JWT_SECRET` | Yes | - | Secret key for signing JWT tokens (generate with `openssl rand -base64 64`) |
-| `JWT_ACCESS_TOKEN_EXPIRY` | No | `900` | Access token expiration in seconds (15 minutes) |
-| `JWT_REFRESH_TOKEN_EXPIRY` | No | `604800` | Refresh token expiration in seconds (7 days) |
-| `ADMIN_USERNAME` | No | `admin` | Default admin username (first-time setup) |
-| `ADMIN_PASSWORD` | No | auto-generated | Admin password for first-time setup. If not set, a random 20-character password is generated and written to `{STORAGE_PATH}/admin.password` (default: `/data/storage/admin.password`). The API is locked until the admin changes this password. Set this env var to skip the setup lock entirely. |
+| `JWT_EXPIRATION_SECS` | No | `86400` | Legacy JWT token expiration in seconds (24 hours). Prefer the two settings below. |
+| `JWT_ACCESS_TOKEN_EXPIRY_MINUTES` | No | `30` | Access token expiration in minutes |
+| `JWT_REFRESH_TOKEN_EXPIRY_DAYS` | No | `7` | Refresh token expiration in days |
+| `ADMIN_PASSWORD` | No | auto-generated | Admin password for first-time setup. If not set, a random password is generated and written to `{STORAGE_PATH}/admin.password` (default: `/data/storage/admin.password`). The API is locked until the admin changes this password. Set this env var to skip the setup lock entirely. |
 | `SKIP_ADMIN_PROVISIONING` | No | `false` | Skip built-in admin user creation on first boot. Use for SSO-only deployments where admin roles are assigned via OIDC/LDAP/SAML group mapping. |
 | `SSO_ENCRYPTION_KEY` | No | - | Encryption key for storing OIDC/LDAP/SAML client secrets in the database |
 | `REQUIRE_HTTPS` | No | `false` | Require HTTPS for all connections |
-| `RATE_LIMIT_LOGIN` | No | `5` | Maximum login attempts |
-| `RATE_LIMIT_WINDOW` | No | `300` | Rate limit window in seconds (5 minutes) |
+| `ALLOW_LOCAL_ADMIN_LOGIN` | No | `false` | When SSO is enabled, local login is disabled by default. Set to `true` to allow the built-in admin account to log in with local credentials even when SSO providers are configured. Intended as a break-glass recovery mechanism. See [Authentication Security](/docs/security/authentication). |
+
+Login attempt limits are configured in the [Rate Limiting](#rate-limiting) section, and brute-force lockout in [Account Lockout](#account-lockout) below.
+
+## Account Lockout
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `ACCOUNT_LOCKOUT_THRESHOLD` | No | `5` | Number of consecutive failed login attempts before a local account is locked. Set to 0 to disable account lockout. |
+| `ACCOUNT_LOCKOUT_DURATION_MINUTES` | No | `30` | Duration in minutes that a locked account remains locked before the user can try again |
+
+## Password Policy
+
+These settings apply to local users only. SSO users authenticate through their identity provider and are not subject to local password policy. See the [Authentication Security](/docs/security/authentication) page for enforcement detail and the `force-password-change` admin API.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PASSWORD_MIN_LENGTH` | No | `8` | Minimum password length |
+| `PASSWORD_MAX_LENGTH` | No | `128` | Maximum password length |
+| `PASSWORD_REQUIRE_UPPERCASE` | No | `false` | Require at least one uppercase letter |
+| `PASSWORD_REQUIRE_LOWERCASE` | No | `false` | Require at least one lowercase letter |
+| `PASSWORD_REQUIRE_DIGIT` | No | `false` | Require at least one digit |
+| `PASSWORD_REQUIRE_SPECIAL` | No | `false` | Require at least one special character |
+| `PASSWORD_MIN_STRENGTH` | No | `0` | Minimum zxcvbn strength score. 0 disables the check. Values 1 through 4 are increasingly strict. |
+| `PASSWORD_HISTORY_COUNT` | No | `0` | Number of previous passwords to remember. New passwords are rejected if they match any of the last N hashes. Set to 0 to disable (max 24). |
+| `PASSWORD_EXPIRY_DAYS` | No | `0` | Number of days after which a local user's password expires and must be changed. Set to 0 to disable (max 3650). |
+
+## Quarantine
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `QUARANTINE_ENABLED` | No | `false` | Hold newly uploaded artifacts in quarantine until security scanning completes or the hold period expires. Downloads return 409 while an artifact is quarantined. |
+| `QUARANTINE_DURATION_MINUTES` | No | `60` | Default quarantine hold period in minutes. Per-repository overrides are available via the `repository_config` table keys `quarantine_enabled` and `quarantine_duration_minutes`. |
 
 ## LDAP Integration
 
@@ -126,6 +160,8 @@ When `STORAGE_BACKEND=s3`. Read by the **backend** process.
 | `S3_MULTIPART_CHUNK_SIZE` | No | `10485760` | Multipart chunk size in bytes (10 MB) |
 | `S3_MAX_CONNECTIONS` | No | `50` | Maximum S3 connections |
 | `S3_USE_TRANSFER_ACCELERATION` | No | `false` | Enable S3 transfer acceleration (AWS only) |
+| `S3_CA_CERT_PATH` | No | - | PEM file with custom CA certificate(s) for the S3 endpoint |
+| `S3_INSECURE_TLS` | No | `false` | Disable TLS verification for S3 (development/testing only) |
 
 ### CloudFront CDN (optional, for S3 backends)
 
@@ -259,6 +295,18 @@ Read by the **backend** process.
 | `SCAN_ON_UPLOAD` | No | `false` | Automatically scan artifacts on upload |
 | `BLOCK_VULNERABLE_UPLOADS` | No | `false` | Block uploads with critical vulnerabilities |
 | `VULNERABILITY_SEVERITY_THRESHOLD` | No | `HIGH` | Severity threshold (CRITICAL, HIGH, MEDIUM, LOW) |
+| `OPENSCAP_URL` | No | - | OpenSCAP wrapper URL for compliance scanning |
+| `OPENSCAP_PROFILE` | No | `xccdf_org.ssgproject.content_profile_standard` | OpenSCAP SCAP profile to evaluate |
+| `SCAN_WORKSPACE_PATH` | No | `/scan-workspace` | Temporary workspace directory for scanning artifacts |
+| `GITHUB_TOKEN` | No | - | GitHub token for downloading advisory databases during scanning |
+
+## Dependency-Track Integration
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DEPENDENCY_TRACK_URL` | No | - | Dependency-Track API URL for vulnerability management |
+| `DEPENDENCY_TRACK_API_KEY` | No | - | Dependency-Track API key |
+| `DEPENDENCY_TRACK_ENABLED` | No | `true` | Enable Dependency-Track integration (takes effect only when the URL is set) |
 
 ## Monitoring & Observability
 
@@ -266,22 +314,96 @@ Read by the **backend** process.
 |----------|----------|---------|-------------|
 | `METRICS_ENABLED` | No | `true` | Enable Prometheus metrics |
 | `METRICS_PATH` | No | `/metrics` | Metrics endpoint path |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | - | OTLP gRPC endpoint for distributed tracing (e.g., `http://jaeger:4317`). When unset, tracing exports are disabled and logging is stdout-only. |
+| `METRICS_PORT` | No | - | Port for an unauthenticated Prometheus metrics-only listener. When set, a second TCP listener serves only `GET /metrics` with no authentication. Intended for internal Prometheus scraping where the scraper cannot present credentials. Ensure this port is not reachable from untrusted networks. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | - | OTLP endpoint for distributed tracing (e.g., `http://jaeger:4317`). When unset, tracing exports are disabled and logging is stdout-only. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | No | `grpc` | Type of exporter for [OpenTelemetry](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/) (either `grpc` or `http/protobuf`) |
 | `OTEL_SERVICE_NAME` | No | `artifact-keeper` | Service name reported in traces |
 | `AUDIT_LOG_ENABLED` | No | `true` | Enable audit logging |
 | `AUDIT_LOG_PATH` | No | `/var/log/artifact-keeper/audit.log` | Audit log file path |
+
+## Rate Limiting
+
+The built-in rate limiter is per-instance (in-memory). For multi-instance deployments behind a load balancer, configure rate limiting at the ingress level (NGINX `limit_req`, Envoy, or a cloud WAF) in addition to these settings.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `RATE_LIMIT_ENABLED` | No | `true` | Master switch for the built-in rate limiter. Set to `false` to disable it entirely. |
+| `RATE_LIMIT_AUTH_PER_MIN` | No | `120` | Maximum authentication requests per window |
+| `RATE_LIMIT_API_PER_MIN` | No | `10000` | Maximum API requests per window |
+| `RATE_LIMIT_WINDOW_SECS` | No | `60` | Window duration in seconds for the auth/API buckets |
+| `RATE_LIMIT_EXEMPT_USERNAMES` | No | - | Comma-separated list of usernames exempt from rate limiting. Useful for CI/CD pipelines, automation bots, and build systems. |
+| `RATE_LIMIT_EXEMPT_SERVICE_ACCOUNTS` | No | `false` | Exempt all service accounts from rate limiting |
+
+### Login and Password-Change Limiter
+
+A dedicated limiter protects the login and password-change endpoints against brute force. It is separate from the API/auth buckets above and has its own window.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `RATE_LIMIT_LOGIN_PER_WINDOW` | No | `10` | Maximum login attempts per source within the login window |
+| `RATE_LIMIT_LOGIN_WINDOW_SECS` | No | `900` | Login limiter window in seconds (15 minutes) |
+| `RATE_LIMIT_LOGIN_GLOBAL_PER_WINDOW` | No | `8192` | Global cap on total login attempts across all sources per window (backstop against distributed brute force / CPU-DoS on password hashing) |
+| `RATE_LIMIT_PASSWORD_CHANGE_PER_WINDOW` | No | `5` | Maximum password-change attempts per source within the window |
+| `RATE_LIMIT_PASSWORD_CHANGE_WINDOW_SECS` | No | `900` | Password-change limiter window in seconds (15 minutes) |
+| `RATE_LIMIT_TRUSTED_PROXY_CIDRS` | No | - | Comma-separated CIDRs of trusted reverse proxies. Only from these sources is the client IP taken from `X-Forwarded-For` for per-source limiting; otherwise the direct socket peer is used. Prevents header-spoofed limiter evasion. |
 
 ## Performance Tuning
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `WORKER_THREADS` | No | `4` | Number of worker threads |
-| `MAX_UPLOAD_SIZE_MB` | No | `10240` | Maximum upload size (10 GB) |
+| `MAX_UPLOAD_SIZE` | No | `10737418240` | Maximum upload size in bytes (10 GB). Set to 0 to disable the limit. |
 | `MAX_CONCURRENT_UPLOADS` | No | `10` | Maximum concurrent uploads |
 | `CHUNK_SIZE_MB` | No | `10` | Upload chunk size (MB) |
 | `CACHE_ENABLED` | No | `true` | Enable metadata caching |
-| `CACHE_TTL_SECONDS` | No | `3600` | Cache TTL (1 hour) |
 | `CACHE_SIZE_MB` | No | `1024` | Cache size (1 GB) |
+
+:::note[Proxy cache TTL]
+There is no `CACHE_TTL_SECONDS` environment variable. The **remote/proxy repository cache** has a default TTL of **86400 seconds (24 hours)** and is configured **per repository** via the repository's `cache-ttl` endpoint — not globally through an environment variable.
+:::
+
+## Scheduled Tasks
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GC_SCHEDULE` | No | `0 0 * * * *` | Cron schedule for storage garbage collection (6-field: sec min hour day month weekday). Default: hourly. |
+| `BLOB_GC_ENABLED` | No | `false` | Opt in to live blob deletion during the GC pass. When `false` (default) the pass dry-runs and only logs what it would remove. |
+| `LIFECYCLE_CHECK_INTERVAL_SECS` | No | `60` | How often (in seconds) the lifecycle scheduler checks for due policies |
+
+## Presigned Download Redirects
+
+When enabled, artifact downloads from storage backends that support presigned URLs (S3, GCS, Azure) return a 302 redirect instead of proxying the bytes through the backend. This reduces bandwidth and CPU usage on the backend server. The per-backend redirect setting must also be enabled (`S3_REDIRECT_DOWNLOADS`, `GCS_REDIRECT_DOWNLOADS`, or `AZURE_REDIRECT_DOWNLOADS`).
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PRESIGNED_DOWNLOADS_ENABLED` | No | `false` | Enable presigned download redirects globally |
+| `PRESIGNED_DOWNLOAD_EXPIRY_SECS` | No | `300` | Presigned URL expiry in seconds (5 minutes) |
+
+## SMTP Email Delivery
+
+Email delivery is disabled when `SMTP_HOST` is not set. Used for password expiration notifications and other system alerts.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SMTP_HOST` | No | - | SMTP server hostname. Email delivery is disabled when unset. |
+| `SMTP_PORT` | No | `587` | SMTP server port |
+| `SMTP_USERNAME` | No | - | SMTP username for authentication |
+| `SMTP_PASSWORD` | No | - | SMTP password for authentication |
+| `SMTP_FROM_ADDRESS` | No | `noreply@artifact-keeper.local` | Default sender address |
+| `SMTP_TLS_MODE` | No | `starttls` | TLS mode: `starttls` (default), `tls`, or `none` |
+
+## gRPC
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `GRPC_PORT` | No | `9090` | Port for the gRPC server |
+| `GRPC_REFLECTION_ENABLED` | No | `false` | Enable gRPC server reflection. Off by default because reflection exposes the full service catalog and schemas to unauthenticated peers; enable only for local dev/CI `grpcurl` tooling. |
+
+## Docker / OCI Registry
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AK_DEFAULT_DOCKER_MIRROR_REPO` | No | - | Repository key used to resolve bare `/v2/<image>/...` OCI pulls that omit a repository segment. Set this to make dockerd's `registry-mirrors` config work against Artifact Keeper; without it, only `/v2/<repo-key>/<image>/...` paths resolve. |
 
 ## Search (OpenSearch)
 
@@ -318,6 +440,31 @@ Search is powered by [OpenSearch](https://opensearch.org/). When `OPENSEARCH_URL
 |----------|----------|---------|-------------|
 | `ALLOW_HTTP_INTEGRATIONS` | No | `false` | Allow HTTP (non-TLS) connections for remote repository proxying, Artifactory migration, and Dependency-Track integration. Required when upstream services use plain HTTP, which is common in air-gapped or development environments. When `false`, all outbound connections to external services enforce HTTPS. |
 | `CUSTOM_CA_CERT_PATH` | No | - | Path to a PEM file containing one or more custom CA certificates. Used for HTTPS connections to internal services (Artifactory, Nexus, remote repositories) that use certificates signed by a private CA. Mount the cert file into the container and set this path (e.g., `/etc/ssl/certs/custom-ca.pem`). The file can contain multiple certificates for CA bundles. |
+| `AK_ENFORCE_HTTPS` | No | `false` | Force the `Secure` flag on auth cookies (and treat requests as HTTPS) even when the direct connection is plain HTTP. Set to `true` when terminating TLS at a proxy. Ignored when `ENVIRONMENT=development`. |
+| `AK_EXTERNAL_URL` | No | - | The trusted public base URL of the deployment (e.g., `https://registry.example.com`). Used to build absolute callback/ACS URLs (SAML, OIDC) instead of trusting request headers, which closes a host-header spoofing vector. |
+| `AK_GUEST_ACCESS_ENABLED` | No | `true` | Allow unauthenticated read of public repositories. Set to `false` (or `0`) to require authentication for all access. |
+
+### Outbound Request / SSRF Controls
+
+Every server-initiated outbound request (remote/proxy upstreams, peer replication, webhooks, SSO metadata fetch, plugin URL fetch, CI OIDC) is resolved through an SSRF guard that refuses to connect to private/internal IPs by default. Cloud-metadata (`169.254.169.254`), loopback, and link-local addresses are **hard-blocked at connect time regardless of any of the toggles below** — these allow-lists only re-permit ordinary RFC1918 private ranges for specific outbound classes.
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `AK_SSRF_ALLOW_PRIVATE_CIDRS` | No | - | Comma-separated CIDRs to allow across all outbound classes (e.g., `10.0.0.0/8`). Metadata/loopback/link-local remain hard-blocked. |
+| `UPSTREAM_ALLOW_PRIVATE_IPS` | No | `false` | Allow remote/proxy repository upstreams to reach private IPs |
+| `UPSTREAM_PRIVATE_IP_ALLOWLIST` | No | - | Comma-separated hosts/CIDRs that upstream proxying may reach on private ranges |
+| `WEBHOOK_ALLOW_PRIVATE_IPS` | No | `false` | Allow webhook delivery to private IPs (e.g., an in-cluster receiver) |
+| `SSO_ALLOW_PRIVATE_IPS` | No | `false` | Allow SSO/OIDC/SAML metadata and token fetches to private IPs (e.g., an internal IdP) |
+| `AK_TRUSTED_INTERNAL_ALLOW_PRIVATE_IPS` | No | `false` | Allow the trusted-internal resolver mode (e.g., in-cluster scanner adapters) to reach private IPs while still hard-blocking metadata/loopback/link-local |
+
+### Security Hardening
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `EXPOSE_DETAILED_HEALTH` | No | `false` | When `false`, the public `/health` response hides the git commit SHA and live DB-pool internals. Enable only for trusted internal monitoring. |
+| `SSO_DISABLE_ADMIN_BREAK_GLASS` | No | `false` | Hard-disable the local-admin break-glass login path entirely, even if `ALLOW_LOCAL_ADMIN_LOGIN=true`. Set to `true` to remove the SSO bypass in high-assurance deployments. |
+| `PLUGINS_REQUIRE_SIGNED` | No | `true` | Require a valid signature before a WASM plugin can be installed. Fail-closed: only an explicit `false`/`0` opts out. |
+| `PLUGINS_TRUSTED_PUBKEY` | No | - | Trusted public key used to verify plugin signatures when `PLUGINS_REQUIRE_SIGNED` is in effect. |
 
 ## Development/Testing
 
@@ -397,15 +544,32 @@ OIDC_REDIRECT_URI=https://registry.example.com/api/v1/auth/oidc/callback
 # Database & JWT
 DATABASE_URL=postgres://registry:password@localhost:5432/artifact_registry
 JWT_SECRET=generate-secure-secret-here
-JWT_ACCESS_TOKEN_EXPIRY=300  # 5 minutes
+JWT_ACCESS_TOKEN_EXPIRY_MINUTES=15
 
 # Security
 REQUIRE_HTTPS=true
-RATE_LIMIT_LOGIN=3
+AK_ENFORCE_HTTPS=true
+
+# Account lockout
+ACCOUNT_LOCKOUT_THRESHOLD=3
+ACCOUNT_LOCKOUT_DURATION_MINUTES=60
+
+# Password policy
+PASSWORD_MIN_LENGTH=12
+PASSWORD_REQUIRE_UPPERCASE=true
+PASSWORD_REQUIRE_LOWERCASE=true
+PASSWORD_REQUIRE_DIGIT=true
+PASSWORD_REQUIRE_SPECIAL=true
+PASSWORD_MIN_STRENGTH=3
+PASSWORD_HISTORY_COUNT=12
+PASSWORD_EXPIRY_DAYS=90
+
+# Scanning
 TRIVY_ENABLED=true
 SCAN_ON_UPLOAD=true
 BLOCK_VULNERABLE_UPLOADS=true
 VULNERABILITY_SEVERITY_THRESHOLD=HIGH
+QUARANTINE_ENABLED=true
 
 # Backups
 BACKUP_ENABLED=true

--- a/src/content/docs/docs/security/authentication.mdx
+++ b/src/content/docs/docs/security/authentication.mdx
@@ -1,0 +1,221 @@
+---
+title: "Authentication Security"
+description: "Account lockout, password policies, password expiration, and password history"
+---
+
+Artifact Keeper provides several mechanisms to protect local user accounts. These features apply only to local (non-SSO) accounts. Users who authenticate through OIDC, LDAP, or SAML are subject to the password policies of their identity provider instead.
+
+## Account Lockout
+
+Account lockout protects against brute-force login attacks by temporarily locking accounts after repeated failed attempts.
+
+### Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ACCOUNT_LOCKOUT_THRESHOLD` | `5` | Number of consecutive failed login attempts before the account is locked. Set to 0 to disable lockout entirely. |
+| `ACCOUNT_LOCKOUT_DURATION_MINUTES` | `30` | How long (in minutes) a locked account remains locked |
+
+### How It Works
+
+Each local user account tracks a counter of consecutive failed login attempts. When this counter reaches the `ACCOUNT_LOCKOUT_THRESHOLD`, the account is locked for `ACCOUNT_LOCKOUT_DURATION_MINUTES`.
+
+During the lockout period:
+
+- The login endpoint returns an error indicating the account is locked
+- The lockout duration is calculated from the time of the last failed attempt
+- No additional failed attempts can extend the lockout period
+
+After the lockout period expires, the user can attempt to log in again. A successful login resets the failed attempt counter to zero and clears the lockout timestamp.
+
+### Example Configuration
+
+For a strict environment that locks accounts after 3 failures for one hour:
+
+```bash
+ACCOUNT_LOCKOUT_THRESHOLD=3
+ACCOUNT_LOCKOUT_DURATION_MINUTES=60
+```
+
+To disable account lockout:
+
+```bash
+ACCOUNT_LOCKOUT_THRESHOLD=0
+```
+
+### Unlocking Accounts
+
+Administrators can unlock a user account before the lockout period expires through the admin API or the web UI. The admin API endpoint resets the failed login counter and clears the `locked_until` timestamp.
+
+## Password Policies
+
+Password policies enforce minimum complexity requirements when users create or change passwords. These rules are checked server-side during registration, password change, and admin-initiated password reset.
+
+### Complexity Requirements
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PASSWORD_MIN_LENGTH` | `8` | Minimum password length |
+| `PASSWORD_MAX_LENGTH` | `128` | Maximum password length |
+| `PASSWORD_REQUIRE_UPPERCASE` | `false` | Require at least one uppercase letter (A-Z) |
+| `PASSWORD_REQUIRE_LOWERCASE` | `false` | Require at least one lowercase letter (a-z) |
+| `PASSWORD_REQUIRE_DIGIT` | `false` | Require at least one digit (0-9) |
+| `PASSWORD_REQUIRE_SPECIAL` | `false` | Require at least one special character |
+
+### Strength Scoring (zxcvbn)
+
+In addition to the character-class requirements above, you can enable the [zxcvbn](https://github.com/dropbox/zxcvbn) password strength estimator. This algorithm evaluates password entropy by checking for common patterns (dictionary words, keyboard sequences, dates, repeated characters) and assigns a score from 0 to 4.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PASSWORD_MIN_STRENGTH` | `0` | Minimum zxcvbn score. 0 disables the check. |
+
+Score meanings:
+
+| Score | Strength | Approximate Guesses |
+|-------|----------|---------------------|
+| 0 | Too weak | < 10^3 |
+| 1 | Weak | < 10^6 |
+| 2 | Fair | < 10^8 |
+| 3 | Strong | < 10^10 |
+| 4 | Very strong | >= 10^10 |
+
+Setting `PASSWORD_MIN_STRENGTH=3` is a good balance for most organizations. It prevents passwords like `Password1!` (which passes character-class checks but is trivially guessable) while still accepting reasonable passphrases.
+
+### Recommended Production Configuration
+
+```bash
+PASSWORD_MIN_LENGTH=12
+PASSWORD_REQUIRE_UPPERCASE=true
+PASSWORD_REQUIRE_LOWERCASE=true
+PASSWORD_REQUIRE_DIGIT=true
+PASSWORD_REQUIRE_SPECIAL=true
+PASSWORD_MIN_STRENGTH=3
+```
+
+## Password History
+
+Password history prevents users from cycling back to previously used passwords.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PASSWORD_HISTORY_COUNT` | `0` | Number of previous passwords to remember (max 24). 0 disables history checking. |
+
+When a user changes their password, the new password is checked against the last N stored password hashes. If the new password matches any of them, it is rejected with a validation error.
+
+The backend stores only bcrypt hashes of previous passwords, not the plaintext values.
+
+### Example
+
+To remember the last 12 passwords:
+
+```bash
+PASSWORD_HISTORY_COUNT=12
+```
+
+With this setting, a user must cycle through 12 different passwords before they can reuse an old one.
+
+## Password Expiration
+
+Password expiration forces local users to change their passwords periodically. This is commonly required for compliance with standards like SOC 2, HIPAA, and PCI DSS.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PASSWORD_EXPIRY_DAYS` | `0` | Require password change after this many days (max 3650). 0 disables expiration. |
+
+### How It Works
+
+The backend tracks a `password_changed_at` timestamp for each user. During login, if the difference between the current time and `password_changed_at` exceeds `PASSWORD_EXPIRY_DAYS`, the backend sets the `must_change_password` flag on the user.
+
+When `must_change_password` is set:
+
+- The login response includes `"must_change_password": true`
+- The web UI redirects the user to a password change form
+- API requests (except password change) may return 403 until the password is updated
+- Changing the password clears the flag and records a new `password_changed_at` timestamp
+
+### Example
+
+For a 90-day password expiration policy:
+
+```bash
+PASSWORD_EXPIRY_DAYS=90
+```
+
+## Force Password Change (Admin API)
+
+Administrators can force any local user to change their password on next login using the `force-password-change` endpoint. This is useful for:
+
+- Responding to credential compromise
+- Onboarding new users with temporary passwords
+- Enforcing password rotation during a security incident
+
+### API Request
+
+```bash
+curl -X POST https://registry.example.com/api/v1/users/{user-id}/force-password-change \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+### Response
+
+```json
+{
+  "message": "User must change password on next login"
+}
+```
+
+### Behavior
+
+When this endpoint is called:
+
+1. The user's `must_change_password` flag is set to `true`
+2. All existing sessions for the user are invalidated
+3. On the user's next login, they will be required to set a new password
+
+This endpoint requires admin privileges. It cannot be used on SSO users (returns 422) since their passwords are managed by the identity provider.
+
+## Combining Features
+
+These features work together. A common enterprise configuration might look like this:
+
+```bash
+# Lock after 5 failures for 30 minutes
+ACCOUNT_LOCKOUT_THRESHOLD=5
+ACCOUNT_LOCKOUT_DURATION_MINUTES=30
+
+# Strong password requirements
+PASSWORD_MIN_LENGTH=12
+PASSWORD_REQUIRE_UPPERCASE=true
+PASSWORD_REQUIRE_LOWERCASE=true
+PASSWORD_REQUIRE_DIGIT=true
+PASSWORD_MIN_STRENGTH=3
+
+# Prevent password reuse
+PASSWORD_HISTORY_COUNT=12
+
+# Require rotation every 90 days
+PASSWORD_EXPIRY_DAYS=90
+
+# Email notifications for expiration warnings
+SMTP_HOST=smtp.corp.example.com
+SMTP_PORT=587
+SMTP_FROM_ADDRESS=noreply@registry.corp.example.com
+```
+
+With this configuration, local users must:
+- Choose a password at least 12 characters long with mixed case and a digit
+- Pass the zxcvbn strength estimator at level 3 or above
+- Not reuse any of their last 12 passwords
+- Change their password at least every 90 days
+- Accept account lockout after 5 consecutive bad attempts
+
+## SSO Break-Glass Recovery
+
+When SSO (OIDC, LDAP, or SAML) is enabled, local login is disabled by default. If SSO becomes misconfigured and administrators are locked out, the break-glass setting allows the built-in admin account to bypass SSO and log in with local credentials.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ALLOW_LOCAL_ADMIN_LOGIN` | `false` | Allow the admin account to use local credentials when SSO is active |
+
+This should be left disabled in normal operation. Enable it only when recovering from an SSO outage or misconfiguration. To hard-disable the break-glass path entirely (even when `ALLOW_LOCAL_ADMIN_LOGIN` is set), set `SSO_DISABLE_ADMIN_BREAK_GLASS=true`.


### PR DESCRIPTION
Consolidates three open, colliding PRs against `reference/environment.mdx` into a single reference refresh, rebased onto current `main` (post OpenSearch migration) and verified end-to-end against backend `src/config.rs`. `npm run build` passes.

## Supersedes (please close with thanks after merge)
- #55 (@brandonrc) — installer + auth-security pages, large env expansion
- #50 (@brandonrc) — publish URLs + BIND_ADDRESS + rate-limit vars
- #53 (@Firjens) — `OTEL_EXPORTER_OTLP_PROTOCOL`

## What it folds in
**From #55:** new pages `getting-started/quickstart-installer.mdx` and `security/authentication.mdx` (both registered in the sidebar); env additions for Account Lockout, Password Policy, Quarantine, Presigned Downloads, SMTP, Scheduled Tasks, gRPC, Dependency-Track, OpenSCAP, S3 CA certs, `METRICS_PORT`, `MAX_UPLOAD_SIZE`, `JWT_*_EXPIRY_*`, `ALLOW_LOCAL_ADMIN_LOGIN`, `SKIP_MIGRATIONS`, installer `AK_VERSION`/`AK_MINIMAL`/`AK_SKIP_START`.

**From #50:** quickstart publish URLs — npm/maven/pypi at bare `/npm`,`/maven`,`/pypi` and docker via OCI `/v2` (confirmed in `src/api/routes.rs`); `BIND_ADDRESS=0.0.0.0:8080` (removed the non-existent `PORT`/`HOST`); `RATE_LIMIT_AUTH_PER_MIN` / `RATE_LIMIT_WINDOW_SECS`.

**From #53:** `OTEL_EXPORTER_OTLP_PROTOCOL` (default `grpc`, accepts `grpc` and `http/protobuf`) in the Monitoring table and `monitoring/tracing.mdx` (verified in `src/telemetry.rs`).

## Corrected stale defaults (verified vs `config.rs`)
| Variable | Was | Now |
|---|---|---|
| `RATE_LIMIT_API_PER_MIN` | 5000 | **10000** |
| `DATABASE_MAX_CONNECTIONS` | 20 | **50** |
| `DATABASE_ACQUIRE_TIMEOUT_SECS` | 30 | **5** |

## Issue fixes
- **Closes #63** — added `AK_DEFAULT_DOCKER_MIRROR_REPO` (in `oci_v2.rs`); reworded the phantom `CACHE_TTL_SECONDS` row: there is no such env var — the remote/proxy cache TTL default is **86400s** (`DEFAULT_CACHE_TTL_SECS`) and is set per-repo via the cache-ttl endpoint.
- **Closes #73** — `advanced/storage.mdx` no longer shows the non-existent `GC_ENABLED`/`GC_RETENTION_DAYS`/`GC_DRY_RUN`; the real vars are `GC_SCHEDULE` and `BLOB_GC_ENABLED`, with retention governed by lifecycle policies.

## New Network Security section
SSRF/outbound controls (`AK_SSRF_ALLOW_PRIVATE_CIDRS`, `WEBHOOK/SSO/UPSTREAM_ALLOW_PRIVATE_IPS`, `UPSTREAM_PRIVATE_IP_ALLOWLIST`, `AK_TRUSTED_INTERNAL_ALLOW_PRIVATE_IPS`), the login/password-change rate limiter (`RATE_LIMIT_LOGIN_*`, `RATE_LIMIT_PASSWORD_CHANGE_*`, `RATE_LIMIT_TRUSTED_PROXY_CIDRS`), and hardening toggles (`EXPOSE_DETAILED_HEALTH`, `GRPC_REFLECTION_ENABLED`, `AK_ENFORCE_HTTPS`, `AK_EXTERNAL_URL`, `AK_GUEST_ACCESS_ENABLED`, `SSO_DISABLE_ADMIN_BREAK_GLASS`, `PLUGINS_REQUIRE_SIGNED`, `PLUGINS_TRUSTED_PUBKEY`). Cloud-metadata/loopback/link-local stay hard-blocked regardless of any toggle.

## Notes for the maintainer
- Every documented name + default was checked in backend source. Unverifiable vars from #55 were **deliberately omitted**: `DTRACK_HTTP_PROXY_*`/`DTRACK_NO_PROXY` (not read anywhere) and the expanded LDAP attribute vars (not in `config.rs`).
- #55 also tweaked `getting-started/configuration.mdx` (duplicate lockout/password tables + link fixes). Left out here to avoid duplicating the new `authentication.mdx`/`environment.mdx` content — cherry-pick if you want the link fixes.
