### PR TITLE
docs: Builds API guide + Docker corporate-proxy troubleshooting (Closes #72, Closes #45)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -142,6 +142,7 @@ export default defineConfig({
             { label: 'Package Manager Configuration', slug: 'docs/reference/cli' },
             { label: 'Environment Variables', slug: 'docs/reference/environment' },
             { label: 'CI/CD Integration', slug: 'docs/guides/ci-cd' },
+            { label: 'Builds API', slug: 'docs/guides/builds' },
             { label: 'UI Gallery', slug: 'docs/ui-gallery' },
           ],
         },

--- a/src/content/docs/docs/deployment/docker.mdx
+++ b/src/content/docs/docs/deployment/docker.mdx
@@ -253,6 +253,61 @@ If you can submit the login form without errors but the UI redirects back to log
 
 Fix: configure TLS on your reverse proxy, or set `ENVIRONMENT=development` on the backend for HTTP-only setups. See [Reverse Proxy & TLS](/docs/deployment/reverse-proxy) for details.
 
+### Corporate proxy / all services show 503 unhealthy
+
+**Symptom:** On a host that is behind a corporate proxy (`HTTP_PROXY` / `HTTPS_PROXY`
+set in the environment or in the Docker daemon config), every service reports `503` /
+`unhealthy` even though the containers are running. `docker compose ps` shows services
+never becoming healthy, and the backend cannot reach the database, OpenSearch, Trivy, or
+Dependency-Track.
+
+**Cause:** Docker and Podman propagate the host's proxy variables into containers. The
+backend uses `reqwest`, which honours `HTTP_PROXY`/`HTTPS_PROXY` natively, so its
+**internal container-to-container** health checks and service calls (e.g. to `opensearch`,
+`trivy`, `postgres`) get routed through the external corporate proxy. The proxy cannot
+resolve or reach those internal Compose service names, so the connections fail and the
+services report unhealthy.
+
+**Diagnosis:** Check the proxy variables the backend container actually sees:
+
+```bash
+docker compose exec backend env | grep -i proxy
+```
+
+If `HTTP_PROXY`/`HTTPS_PROXY` are set but `no_proxy` does not list the internal service
+names, the proxy is intercepting internal traffic.
+
+**Fix:** The bundled `docker-compose.yml` sets `no_proxy` on the backend to exclude the
+internal service hostnames from proxying:
+
+```yaml
+no_proxy: "${NO_PROXY:-},localhost,127.0.0.1,db,postgres,opensearch,trivy,openscap,dependency-track-apiserver"
+```
+
+If you are on a current deployment, this is already in place — just make sure you are not
+overriding `no_proxy`/`NO_PROXY` with a value that drops those hostnames. **Older
+deployments** (or custom Compose files) that predate this change must add the internal
+service hostnames to `NO_PROXY` themselves:
+
+```bash
+NO_PROXY=localhost,127.0.0.1,db,postgres,opensearch,trivy,openscap,dependency-track-apiserver
+```
+
+If you run additional services, add their Compose service names to the list as well.
+Restart the stack after changing proxy variables:
+
+```bash
+docker compose up -d --force-recreate
+```
+
+:::note[Dependency-Track proxy settings]
+Dependency-Track does not read `HTTP_PROXY`/`no_proxy`. It uses its own Alpine-style
+variables instead. When it genuinely needs the corporate proxy to mirror the NVD /
+external vulnerability data, configure `ALPINE_HTTP_PROXY_ADDRESS`,
+`ALPINE_HTTP_PROXY_PORT`, `ALPINE_HTTP_PROXY_USERNAME`, and `ALPINE_HTTP_PROXY_PASSWORD`,
+and exclude internal hosts with `ALPINE_NO_PROXY` (defaults to `localhost,127.0.0.1`).
+:::
+
 ### Out of Disk Space
 
 ```bash

--- a/src/content/docs/docs/guides/builds.mdx
+++ b/src/content/docs/docs/guides/builds.mdx
@@ -1,0 +1,335 @@
+---
+title: "Populating the Builds UI via the Builds API"
+description: "Create builds, attach artifacts, and mark build status over the REST API so the Builds UI shows your CI runs"
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+The **Builds** screen in the web UI is populated from the Builds REST API. A "build"
+is a first-class record of a CI/CD run — its name, build number, VCS metadata, timing,
+status, and the artifacts it produced. Your pipeline calls the API to create a build,
+attach the artifacts it published, and mark it complete; the UI then renders it.
+
+All Builds endpoints are mounted under `/api/v1/builds`.
+
+## Authentication
+
+Every Builds endpoint requires authentication. Send a bearer token in the
+`Authorization` header:
+
+```http
+Authorization: Bearer <access_token>
+```
+
+You can obtain a token from `POST /auth/login`, or (recommended for pipelines) use a
+long-lived API token issued to a service account. See the
+[REST API Reference](/docs/reference/api/) and
+[Authentication & RBAC](/docs/advanced/auth/) for how to obtain and scope tokens.
+
+Requests without a valid token receive `401 Authentication required`.
+
+:::note[Base URL]
+Examples below use `https://registry.example.com` as the instance base URL. Replace it
+with your own. The API prefix is always `/api/v1`.
+:::
+
+## Endpoints at a glance
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `POST` | `/api/v1/builds/` | Create a build (starts in `running`) |
+| `GET`  | `/api/v1/builds/` | List builds (paginated, filterable) |
+| `GET`  | `/api/v1/builds/{id}` | Fetch a single build |
+| `PUT`  | `/api/v1/builds/{id}` | Update a build's status (and finish time) |
+| `POST` | `/api/v1/builds/{id}/artifacts` | Attach artifacts to a build |
+| `GET`  | `/api/v1/builds/diff` | Diff the artifacts of two builds |
+
+## Build status values
+
+A build's `status` is stored as a free-form string, but the service layer validates it
+on update. The accepted values are:
+
+- `pending`
+- `running`
+- `success`
+- `failed`
+- `cancelled`
+
+A newly created build starts in `running`. Sending any other value to the update
+endpoint returns `400` with:
+
+```
+Invalid build status: <value>. Must be one of: pending, running, success, failed, cancelled
+```
+
+These values are enforced by the backend service (`update_status`), not by a fixed API
+enum — so they are the authoritative set the server will accept.
+
+## Create a build
+
+`POST /api/v1/builds/`
+
+Creates a build record. Only `name` and `build_number` are required; the VCS and
+`metadata` fields are optional but recommended so the UI can link back to source.
+
+**Request body:**
+
+```json
+{
+  "name": "my-service",
+  "build_number": 42,
+  "agent": "github-actions",
+  "started_at": "2026-07-11T10:00:00Z",
+  "vcs_url": "https://github.com/acme/my-service",
+  "vcs_revision": "9fceb02...",
+  "vcs_branch": "main",
+  "vcs_message": "Release 1.4.0",
+  "metadata": { "pipeline_id": "12345" }
+}
+```
+
+**Response** (`200`): a build object. Note the returned field is `number` (not
+`build_number`), and the new build's `status` is `running`:
+
+```json
+{
+  "id": "6b1a...",
+  "name": "my-service",
+  "number": 42,
+  "status": "running",
+  "agent": "github-actions",
+  "started_at": "2026-07-11T10:00:00Z",
+  "created_at": "2026-07-11T10:00:01Z",
+  "updated_at": "2026-07-11T10:00:01Z"
+}
+```
+
+Capture the `id` from this response — you need it to attach artifacts and update status.
+
+```bash
+BUILD_ID=$(curl -sf -X POST https://registry.example.com/api/v1/builds/ \
+  -H "Authorization: Bearer $AK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-service",
+    "build_number": 42,
+    "agent": "github-actions",
+    "vcs_branch": "main",
+    "vcs_revision": "9fceb02"
+  }' | jq -r '.id')
+```
+
+## Attach artifacts
+
+`POST /api/v1/builds/{id}/artifacts`
+
+Attach one or more artifacts to a build. At least one artifact is required, and each
+artifact must have a non-empty `name` and `path`. `module_name` is optional and groups
+artifacts under a build module.
+
+**Request body:**
+
+```json
+{
+  "artifacts": [
+    {
+      "module_name": "server",
+      "name": "my-service.tar.gz",
+      "path": "dist/my-service.tar.gz",
+      "checksum_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "size_bytes": 10485760
+    }
+  ]
+}
+```
+
+```bash
+curl -sf -X POST "https://registry.example.com/api/v1/builds/$BUILD_ID/artifacts" \
+  -H "Authorization: Bearer $AK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"artifacts\": [{
+      \"name\": \"my-service.tar.gz\",
+      \"path\": \"dist/my-service.tar.gz\",
+      \"checksum_sha256\": \"$(sha256sum dist/my-service.tar.gz | cut -d' ' -f1)\",
+      \"size_bytes\": $(stat -c%s dist/my-service.tar.gz)
+    }]
+  }"
+```
+
+## Mark the build complete
+
+`PUT /api/v1/builds/{id}`
+
+Update the build's status once the pipeline finishes. Include `finished_at` on the
+final update so the backend computes `duration_ms` (from `started_at` to `finished_at`).
+
+**Request body:**
+
+```json
+{
+  "status": "success",
+  "finished_at": "2026-07-11T10:05:00Z"
+}
+```
+
+```bash
+curl -sf -X PUT "https://registry.example.com/api/v1/builds/$BUILD_ID" \
+  -H "Authorization: Bearer $AK_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"status\": \"success\", \"finished_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+```
+
+On failure, send `"status": "failed"` (or `"cancelled"`) instead so the UI shows the
+correct outcome.
+
+## List and inspect builds
+
+`GET /api/v1/builds/` returns a paginated list. Supported query parameters:
+
+- `page` (default `1`)
+- `per_page` (default `20`, max `100`)
+- `status` — filter by exact status
+- `search` — case-insensitive match on build name
+- `sort_order` — `asc` (default) or `desc` by build number
+
+```bash
+curl -sf "https://registry.example.com/api/v1/builds/?status=success&per_page=50&sort_order=desc" \
+  -H "Authorization: Bearer $AK_TOKEN" | jq
+```
+
+`GET /api/v1/builds/{id}` returns a single build.
+
+## Diff two builds
+
+`GET /api/v1/builds/diff?build_a=<id>&build_b=<id>` compares the artifacts of two builds
+and returns `added`, `removed`, and `modified` lists:
+
+```bash
+curl -sf "https://registry.example.com/api/v1/builds/diff?build_a=$OLD&build_b=$NEW" \
+  -H "Authorization: Bearer $AK_TOKEN" | jq
+```
+
+## End-to-end CI example
+
+The example below creates a build, attaches the artifact it produced, and marks the
+build complete — after which the run appears on the Builds screen. Store the instance
+URL and token as pipeline secrets.
+
+<Tabs>
+<TabItem label="GitHub Actions">
+
+```yaml
+name: Publish build
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      AK_URL: ${{ secrets.AK_URL }}      # e.g. https://registry.example.com
+      AK_TOKEN: ${{ secrets.AK_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: make build   # produces dist/my-service.tar.gz
+
+      - name: Register build
+        run: |
+          BUILD_ID=$(curl -sf -X POST "$AK_URL/api/v1/builds/" \
+            -H "Authorization: Bearer $AK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"name\": \"my-service\",
+              \"build_number\": ${{ github.run_number }},
+              \"agent\": \"github-actions\",
+              \"vcs_url\": \"${{ github.server_url }}/${{ github.repository }}\",
+              \"vcs_revision\": \"${{ github.sha }}\",
+              \"vcs_branch\": \"${{ github.ref_name }}\"
+            }" | jq -r '.id')
+          echo "BUILD_ID=$BUILD_ID" >> "$GITHUB_ENV"
+
+      - name: Attach artifacts
+        run: |
+          curl -sf -X POST "$AK_URL/api/v1/builds/$BUILD_ID/artifacts" \
+            -H "Authorization: Bearer $AK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"artifacts\": [{
+                \"name\": \"my-service.tar.gz\",
+                \"path\": \"dist/my-service.tar.gz\",
+                \"checksum_sha256\": \"$(sha256sum dist/my-service.tar.gz | cut -d' ' -f1)\",
+                \"size_bytes\": $(stat -c%s dist/my-service.tar.gz)
+              }]
+            }"
+
+      - name: Mark build complete
+        if: success()
+        run: |
+          curl -sf -X PUT "$AK_URL/api/v1/builds/$BUILD_ID" \
+            -H "Authorization: Bearer $AK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"status\": \"success\", \"finished_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+
+      - name: Mark build failed
+        if: failure()
+        run: |
+          curl -sf -X PUT "$AK_URL/api/v1/builds/$BUILD_ID" \
+            -H "Authorization: Bearer $AK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"status\": \"failed\", \"finished_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+```
+
+</TabItem>
+<TabItem label="GitLab CI">
+
+```yaml
+publish:
+  image: alpine:3
+  variables:
+    AK_URL: "https://registry.example.com"
+    # AK_TOKEN is a masked CI/CD variable
+  before_script:
+    - apk add --no-cache curl jq coreutils
+  script:
+    - make build   # produces dist/my-service.tar.gz
+    - |
+      BUILD_ID=$(curl -sf -X POST "$AK_URL/api/v1/builds/" \
+        -H "Authorization: Bearer $AK_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"name\": \"my-service\",
+          \"build_number\": ${CI_PIPELINE_IID},
+          \"agent\": \"gitlab-ci\",
+          \"vcs_url\": \"${CI_PROJECT_URL}\",
+          \"vcs_revision\": \"${CI_COMMIT_SHA}\",
+          \"vcs_branch\": \"${CI_COMMIT_REF_NAME}\"
+        }" | jq -r '.id')
+    - |
+      curl -sf -X POST "$AK_URL/api/v1/builds/$BUILD_ID/artifacts" \
+        -H "Authorization: Bearer $AK_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"artifacts\": [{
+            \"name\": \"my-service.tar.gz\",
+            \"path\": \"dist/my-service.tar.gz\",
+            \"checksum_sha256\": \"$(sha256sum dist/my-service.tar.gz | cut -d' ' -f1)\",
+            \"size_bytes\": $(stat -c%s dist/my-service.tar.gz)
+          }]
+        }"
+    - |
+      curl -sf -X PUT "$AK_URL/api/v1/builds/$BUILD_ID" \
+        -H "Authorization: Bearer $AK_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "{\"status\": \"success\", \"finished_at\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
+```
+
+</TabItem>
+</Tabs>
+
+After the pipeline runs, open the **Builds** screen in the web UI — the new build,
+its artifacts, and its final status will be listed.


### PR DESCRIPTION
## Summary

Two documentation additions, verified against the `artifact-keeper` backend source.

### Task 1 — Builds API guide (Closes #72)
New page `src/content/docs/docs/guides/builds.mdx` documenting how to populate the Builds UI via the `/api/v1/builds` API:

- Auth (Bearer token), create build (`POST /api/v1/builds/`), attach artifacts (`POST /api/v1/builds/{id}/artifacts`), update status (`PUT /api/v1/builds/{id}`), list (`GET /api/v1/builds/`), diff (`GET /api/v1/builds/diff`).
- curl examples plus end-to-end GitHub Actions and GitLab CI pipelines that create a build, attach artifacts, and mark it complete.
- Build `status` is documented as a free-form string validated at the service layer (`build_service::update_status`), **not** a fixed API enum. The accepted values — `pending`, `running`, `success`, `failed`, `cancelled` — were taken directly from the backend service source. New builds start in `running`.
- Registered in the sidebar next to CI/CD Integration.

### Task 2 — Docker corporate-proxy troubleshooting (Closes #45)
Added a "Corporate proxy / all services show 503 unhealthy" entry to the Docker Compose deployment page Troubleshooting section:

- Symptom: internal container-to-container health checks route through `HTTP_PROXY`/`HTTPS_PROXY`.
- Diagnosis: `docker compose exec backend env | grep -i proxy`.
- Fix: current compose sets `no_proxy` including `localhost,127.0.0.1,db,postgres,opensearch,trivy,openscap,dependency-track-apiserver`; older deployments add the service hostnames to `NO_PROXY`.
- Notes Dependency-Track's `ALPINE_HTTP_PROXY_*` / `ALPINE_NO_PROXY`.
- Uses the current `opensearch` service name (not the stale `meilisearch` reference from the issue).

## Validation
`npm ci && npm run build` passes cleanly (82 pages built).

Closes #72
Closes #45