### PR TITLE
docs(release-notes): add v1.3.0 → v1.5.1 release notes (refs #54)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -148,6 +148,12 @@ export default defineConfig({
         {
           label: 'Release Notes',
           items: [
+            { label: 'v1.5.1', slug: 'docs/release-notes/v1-5-1' },
+            { label: 'v1.5.0', slug: 'docs/release-notes/v1-5-0' },
+            { label: 'v1.4.2', slug: 'docs/release-notes/v1-4-2' },
+            { label: 'v1.4.1', slug: 'docs/release-notes/v1-4-1' },
+            { label: 'v1.4.0', slug: 'docs/release-notes/v1-4-0' },
+            { label: 'v1.3.0', slug: 'docs/release-notes/v1-3-0' },
             { label: 'v1.2.0', slug: 'docs/release-notes/v1-2-0' },
           ],
         },

--- a/src/content/docs/docs/release-notes/v1-3-0.mdx
+++ b/src/content/docs/docs/release-notes/v1-3-0.mdx
@@ -1,0 +1,61 @@
+---
+title: What's new in 1.3.0
+description: Headline changes, security hardening, and upgrade steps for v1.3.0
+---
+
+v1.3.0 is a streaming-focused minor release. The headline theme is that uploads and pull-through downloads now stream end-to-end through the storage backend instead of buffering in memory, blob garbage collection becomes two-phase and idempotent, and the long-running auth/audit epic ([#1617](https://github.com/artifact-keeper/artifact-keeper/issues/1617)) lands its first phases. This page summarises everything you need to know to upgrade.
+
+For the full commit-level changelog, see [the GitHub release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.3.0).
+
+## Headline changes
+
+- **End-to-end streaming uploads** ([#1608](https://github.com/artifact-keeper/artifact-keeper/issues/1608)). Chef/Ansible/Pub multipart uploads ([#2176](https://github.com/artifact-keeper/artifact-keeper/issues/2176)), Helm chart metadata-parsing uploads ([#2180](https://github.com/artifact-keeper/artifact-keeper/issues/2180)), and PyPI/NuGet uploads through a shared content-addressed primitive ([#2199](https://github.com/artifact-keeper/artifact-keeper/issues/2199)) now stream to storage rather than buffering the whole body in memory. A CI streaming-invariant enforcement gate ([#2171](https://github.com/artifact-keeper/artifact-keeper/issues/2171)) plus a required `StorageBackend::put_stream` trait method ([#2207](https://github.com/artifact-keeper/artifact-keeper/issues/2207)) stop backends from silently reintroducing buffering. See [Storage Backends](/docs/advanced/storage/).
+- **Two-phase, idempotent blob garbage collection** ([#1660](https://github.com/artifact-keeper/artifact-keeper/issues/1660)). Blob GC now uses a `pending_delete` marker with an idempotent delete and a two-phase mark-and-sweep ([#2209](https://github.com/artifact-keeper/artifact-keeper/issues/2209), [#2213](https://github.com/artifact-keeper/artifact-keeper/issues/2213)), so a retried or interrupted sweep can no longer orphan or double-delete blobs.
+- **Auth/audit epic — first phases** ([#1617](https://github.com/artifact-keeper/artifact-keeper/issues/1617)). Federated logins and API-token lifecycle events are now audited ([#2187](https://github.com/artifact-keeper/artifact-keeper/issues/2187)), `require_admin` is consolidated onto the `AuthExtension` gate ([#2185](https://github.com/artifact-keeper/artifact-keeper/issues/2185)), and a new `AccessScope` enum for repo-scope authorization ([#2195](https://github.com/artifact-keeper/artifact-keeper/issues/2195)) is threaded through the SBOM and search read paths ([#2194](https://github.com/artifact-keeper/artifact-keeper/issues/2194), [#2205](https://github.com/artifact-keeper/artifact-keeper/issues/2205)).
+- **npm stale-while-revalidate packument cache** ([#2166](https://github.com/artifact-keeper/artifact-keeper/issues/2166)). Computed packuments are now cached with stale-while-revalidate, serving cached metadata immediately while refreshing in the background. See [npm Performance](/docs/guides/npm-performance/).
+- **Composer upstream dist caching** ([#2204](https://github.com/artifact-keeper/artifact-keeper/issues/2204)). Upstream `dist` artifacts are now cached for remote/proxy Composer repositories. See [Composer / PHP](/docs/guides/composer/).
+- **SSO regression harnesses**. New end-to-end harnesses cover OIDC login/callback against a mock IdP ([#2210](https://github.com/artifact-keeper/artifact-keeper/issues/2210)) and SAML ACS signed-assertion flows ([#2214](https://github.com/artifact-keeper/artifact-keeper/issues/2214)).
+
+## Security
+
+- **Scans that error now fail closed** ([#2240](https://github.com/artifact-keeper/artifact-keeper/issues/2240)). A vulnerability scan that errors is no longer reported as a clean artifact; it fails closed. See [Vulnerability Scanning](/docs/security/scanning/).
+- **Global security-policy writes require admin** ([#2223](https://github.com/artifact-keeper/artifact-keeper/issues/2223)). Creating, updating, or deleting a global security policy now requires an admin. See [Security Policies](/docs/security/policies/).
+- **Direct delete gated on promotion-only repos** ([#2239](https://github.com/artifact-keeper/artifact-keeper/issues/2239)). Direct artifact delete is now gated on promotion-only release repositories, closing a bypass of the promotion workflow. See [Staging &amp; Promotion](/docs/advanced/staging-promotion/).
+- **bcrypt bumped for RUSTSEC-2026-0199** ([#2216](https://github.com/artifact-keeper/artifact-keeper/issues/2216)) to 0.19.2.
+
+:::caution[Upgrade notes]
+Two changes alter runtime behavior you should review before upgrading:
+
+- **Auth cookie `Secure` flag** ([#2233](https://github.com/artifact-keeper/artifact-keeper/issues/2233), [#2234](https://github.com/artifact-keeper/artifact-keeper/issues/2234)). The `Secure` flag on auth cookies is now gated on the explicit `AK_ENFORCE_HTTPS` setting, with HTTPS auto-detection via `X-Forwarded-Proto` ([#2236](https://github.com/artifact-keeper/artifact-keeper/issues/2236)). If you terminate TLS at a reverse proxy, set `AK_ENFORCE_HTTPS=true` (or ensure `X-Forwarded-Proto` is passed through) so cookies keep the `Secure` attribute.
+- **Fail-closed scanning** ([#2240](https://github.com/artifact-keeper/artifact-keeper/issues/2240)). Artifacts whose scan errors are no longer treated as clean. If your scanner infrastructure is flaky, expect previously "clean" artifacts to surface as scan errors instead.
+:::
+
+## Bug fixes worth calling out
+
+- **Pull-through cache single-flight and streaming** ([#2172](https://github.com/artifact-keeper/artifact-keeper/issues/2172), [#2178](https://github.com/artifact-keeper/artifact-keeper/issues/2178)). The proxy pull-through cache now uses a cross-replica single-flight via a Postgres advisory lock, and blob downloads stream rather than buffer. Buffered upstream metadata reads are capped ([#2181](https://github.com/artifact-keeper/artifact-keeper/issues/2181), [#2191](https://github.com/artifact-keeper/artifact-keeper/issues/2191)).
+- **Authorization-cache invalidation fans out across replicas** ([#2169](https://github.com/artifact-keeper/artifact-keeper/issues/2169)), so a permission change takes effect on every replica, not just the one that handled the write.
+- **Metrics cardinality guard** ([#2217](https://github.com/artifact-keeper/artifact-keeper/issues/2217)). Unmatched HTTP paths now collapse to a single label, preventing scanner-driven cardinality explosion. See [Prometheus Metrics](/docs/monitoring/metrics/).
+- **Storage backend fixes** ([#2200](https://github.com/artifact-keeper/artifact-keeper/issues/2200)). GCS rewrite-loop token refresh plus S3 copy digest-check and abort-on-drop.
+- **Scanner adapter credential scoping** ([#2238](https://github.com/artifact-keeper/artifact-keeper/issues/2238)). The registry pull credential is scoped to the target image so the Trivy DB pull is not rejected (scanner-adapter 1.1.0, [#2242](https://github.com/artifact-keeper/artifact-keeper/issues/2242)).
+
+## Upgrade path
+
+1. **Pull the new images**:
+   ```bash
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:1.3.0
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-web:1.3.0
+   ```
+2. **Review `AK_ENFORCE_HTTPS`**. If you run behind a TLS-terminating reverse proxy, set `AK_ENFORCE_HTTPS=true` or forward `X-Forwarded-Proto` so auth cookies keep the `Secure` attribute. See [Environment Variables](/docs/reference/environment/).
+3. **Helm**: bump the chart to the v1.3.0-compatible version and apply with `helm upgrade`.
+4. **Docker Compose**: pull the v1.3.0 compose file from the release tarball, copy in your `.env`, and run `docker compose up -d`.
+5. **Verify**: confirm scans complete (or surface as errors rather than false-clean), and that authenticated downloads and uploads work across your formats.
+
+The web UI, CLI, and native clients work unchanged against a 1.3.0 backend. SDKs published to npm, Maven, PyPI, crates.io, and SPM are tagged `1.3.0`.
+
+## Support window
+
+- **1.3.x**: active. Bug fixes, security patches, and feature work all land here.
+- **1.2.x**: maintenance only. Security backports until v1.4.0 ships.
+- **&lt;= 1.1.x**: end of life. Upgrade required.
+
+See [Support Policy](/docs/getting-started/support-policy/) for the full version-support matrix.

--- a/src/content/docs/docs/release-notes/v1-4-0.mdx
+++ b/src/content/docs/docs/release-notes/v1-4-0.mdx
@@ -1,0 +1,65 @@
+---
+title: What's new in 1.4.0
+description: Headline changes, security hardening, and upgrade steps for v1.4.0
+---
+
+v1.4.0 is an auth- and SSO-focused minor release. The headline is keyless CI/CD authentication: pipelines can now exchange a workload OIDC token for an Artifact Keeper token with no long-lived secrets. Alongside that, the release closes several information-disclosure surfaces, adds a dedicated login rate limit, and expands package-format coverage. This page summarises everything you need to know to upgrade.
+
+For the full commit-level changelog, see [the GitHub release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.4.0).
+
+## Headline changes
+
+- **Keyless CI/CD token exchange via OIDC** ([#1142](https://github.com/artifact-keeper/artifact-keeper/issues/1142)). CI pipelines can exchange a workload OIDC token (GitHub Actions, GitLab CI, and other OIDC-issuing runners) for an Artifact Keeper token without provisioning or rotating long-lived secrets. See [Authentication &amp; RBAC](/docs/advanced/auth/) and [CI/CD Integration](/docs/guides/ci-cd/).
+- **OCI OAuth2 refresh-token grant** ([#1166](https://github.com/artifact-keeper/artifact-keeper/issues/1166)). The OCI token endpoint now supports the OAuth2 refresh-token grant and `access_type=offline`, and `/v2/token` accepts repeated `scope` query params for kaniko cross-repo push ([#2276](https://github.com/artifact-keeper/artifact-keeper/issues/2276)). See [Docker / OCI](/docs/guides/docker/).
+- **PyPI non-PEP-503 upstream indexes** ([#1995](https://github.com/artifact-keeper/artifact-keeper/issues/1995)). Remote PyPI repositories can point at upstream indexes that don't follow the PEP 503 path layout via the new `upstream_index_path` repo config field. See [PyPI](/docs/guides/pypi/).
+- **Dart Pub support** ([#2008](https://github.com/artifact-keeper/artifact-keeper/issues/2008)). Pub upload protocol compliance plus Remote/Virtual metadata resolution for Dart packages. See [More Languages](/docs/guides/more-languages/).
+- **Expanded audit coverage** ([#2263](https://github.com/artifact-keeper/artifact-keeper/issues/2263)). TOTP, password-change, and session-invalidation auth events are now recorded, extending the auth/audit epic started in 1.3.0.
+- **Canonical `/users/me` self-service aliases** ([#2265](https://github.com/artifact-keeper/artifact-keeper/issues/2265)) for a user's own record, tokens, and password.
+- **npm cross-replica single-flight for SWR refreshes** ([#2256](https://github.com/artifact-keeper/artifact-keeper/issues/2256)) and storage-backend tracing spans ([#1947](https://github.com/artifact-keeper/artifact-keeper/issues/1947)).
+
+## Security
+
+- **`/health` detail and gRPC reflection gated, off by default** ([#2253](https://github.com/artifact-keeper/artifact-keeper/issues/2253)). Detailed health output and gRPC reflection are now behind config and disabled by default, closing version and topology information leaks. See [Health Checks](/docs/monitoring/health-checks/).
+- **Dedicated strict login rate limit** ([#2297](https://github.com/artifact-keeper/artifact-keeper/issues/2297)). The login endpoint now has its own strict rate limit, separated from the general limiter, so login-throttling tuning no longer trades off against normal API traffic. See [Authentication Security](/docs/security/authentication/).
+- **Sync-policy read/preview routes require admin** ([#2252](https://github.com/artifact-keeper/artifact-keeper/issues/2252)) and **build read endpoints require authentication** ([#2254](https://github.com/artifact-keeper/artifact-keeper/issues/2254)).
+- **cargo-audit advisories cleared** ([#2157](https://github.com/artifact-keeper/artifact-keeper/issues/2157)): crossbeam-epoch RUSTSEC-2026-0204 and the crypto-bigint yank.
+
+:::caution[Upgrade notes]
+Review these behavior changes before upgrading:
+
+- **`/health` detail and gRPC reflection are now off by default** ([#2253](https://github.com/artifact-keeper/artifact-keeper/issues/2253)). If your monitoring parses the detailed `/health` payload or relies on gRPC reflection, you must explicitly re-enable them via config. The default is closed.
+- **OIDC sub-2048-bit RSA keys are rejected by default** ([#2041](https://github.com/artifact-keeper/artifact-keeper/pull/2041)). The strict signature path rejects any RSA modulus below 2048 bits, keeping Artifact Keeper aligned with NIST SP 800-131A and OWASP ASVS. If your IdP still publishes a short RSA key on its JWKS, opt in per provider with the new `allow_legacy_rsa_keys` flag (migration 144, defaults to `false`). The legacy path accepts only RS256/RS384/RS512; PS*, ES*, and HS* tokens never engage it, and audience/issuer/expiry/nonce checks stay in force.
+- **Dedicated login rate limit** ([#2297](https://github.com/artifact-keeper/artifact-keeper/issues/2297)). Login throttling is now separate from the general limiter. If you had tuned the general limiter to protect login, review the new dedicated limit. Confirm your trusted-proxy CIDRs are configured so `X-Forwarded-For` is honored correctly behind a reverse proxy.
+:::
+
+## Bug fixes worth calling out
+
+- **Sync task claiming** ([#2221](https://github.com/artifact-keeper/artifact-keeper/issues/2221)). `sync_tasks` are now claimed before peer side effects run, stopping multi-replica double execution.
+- **apt virtual `dists`** ([#2255](https://github.com/artifact-keeper/artifact-keeper/issues/2255)) no longer swallows a 502 cap-exceeded into an empty 200; InRelease cache invalidation was simplified ([#2232](https://github.com/artifact-keeper/artifact-keeper/issues/2232)).
+- **npm canonical `/-/` tarball paths** ([#2280](https://github.com/artifact-keeper/artifact-keeper/issues/2280)) resolve in the generic download/delete handlers.
+- **OCI virtual-repo blob cache-fill** ([#2281](https://github.com/artifact-keeper/artifact-keeper/issues/2281)) streams instead of buffering at the 8&nbsp;MiB metadata cap.
+- **SBOM/scan not offered for proxy-cached remote artifacts** ([#2291](https://github.com/artifact-keeper/artifact-keeper/issues/2291)).
+- **Azure zero-length body signing** ([#2293](https://github.com/artifact-keeper/artifact-keeper/issues/2293)): Content-Length is left empty in the Shared Key string-to-sign for zero-length bodies.
+
+## Upgrade path
+
+1. **Pull the new images**:
+   ```bash
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:1.4.0
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-web:1.4.0
+   ```
+2. **Run migrations**. Migration 144 adds the per-provider `allow_legacy_rsa_keys` OIDC flag (defaults to `false`); no action is required unless you need the legacy path.
+3. **Re-enable `/health` detail or gRPC reflection** via config if your monitoring depends on them — both are now off by default.
+4. **Review login rate limiting** and your trusted-proxy CIDRs so throttling keys off the real client IP.
+5. **Helm / Docker Compose**: bump to the v1.4.0-compatible chart or compose file and apply.
+6. **Verify**: confirm CI OIDC token exchange works from your pipeline, and that SSO logins still succeed against your IdP.
+
+The web UI, CLI, and native clients work unchanged against a 1.4.0 backend. SDKs published to npm, Maven, PyPI, crates.io, and SPM are tagged `1.4.0`.
+
+## Support window
+
+- **1.4.x**: active. Bug fixes, security patches, and feature work all land here.
+- **1.3.x**: maintenance only. Security backports until the next minor ships.
+- **&lt;= 1.2.x**: end of life. Upgrade required.
+
+See [Support Policy](/docs/getting-started/support-policy/) for the full version-support matrix.

--- a/src/content/docs/docs/release-notes/v1-4-1.mdx
+++ b/src/content/docs/docs/release-notes/v1-4-1.mdx
@@ -1,0 +1,50 @@
+---
+title: What's new in 1.4.1
+description: Bug fixes and a small authorization-baseline change in the v1.4.1 patch release
+---
+
+v1.4.1 is a patch release on top of [1.4.0](/docs/release-notes/v1-4-0/). It aligns the OpenAPI spec with runtime behavior, fixes a handful of storage, format-handler, and auth issues, and adjusts the public-repo read baseline so that logging in never grants *less* access than an anonymous client. There are no breaking changes.
+
+For the full commit-level changelog, see [the GitHub release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.4.1).
+
+## Highlights
+
+- **OpenAPI / runtime alignment** ([#2335](https://github.com/artifact-keeper/artifact-keeper/issues/2335)). The OpenAPI spec is now aligned with runtime behavior on six endpoints, and five schema-name collisions were resolved with the collision ratchet emptied ([#2340](https://github.com/artifact-keeper/artifact-keeper/issues/2340)). This keeps the generated SDKs faithful to the live API. See [REST API](/docs/reference/api/).
+- **Authenticated-user public-repo read baseline** ([#2346](https://github.com/artifact-keeper/artifact-keeper/issues/2346)). Authenticated users are now granted the anonymous read baseline on public repositories, so logging in can no longer see less than an anonymous client would.
+
+## Fixes
+
+- **Auth**: the guest-access guard now returns 503 (not 401) when the auth path is overloaded ([#2315](https://github.com/artifact-keeper/artifact-keeper/issues/2315)), and the credential watermark check tolerates app-vs-DB clock skew ([#2350](https://github.com/artifact-keeper/artifact-keeper/issues/2350)).
+- **Azure storage**: the health-check HEAD probe is signed in Shared Key mode ([#2295](https://github.com/artifact-keeper/artifact-keeper/issues/2295)), and the SAS signed start is backdated 15 minutes to tolerate clock skew ([#2294](https://github.com/artifact-keeper/artifact-keeper/issues/2294)).
+- **npm**: the packument cache buffer cap was raised ([#2313](https://github.com/artifact-keeper/artifact-keeper/issues/2313)).
+- **Swift**: release versions are aggregated across all virtual repo members ([#2342](https://github.com/artifact-keeper/artifact-keeper/issues/2342)).
+- **Signing**: `key_type` is normalized so RSA algorithm variants no longer 500 at key creation ([#2344](https://github.com/artifact-keeper/artifact-keeper/issues/2344)). See [Artifact Signing](/docs/security/signing/).
+- **Scanner**: a scan records `not_applicable` when the Trivy CLI is absent instead of failing outright ([#2324](https://github.com/artifact-keeper/artifact-keeper/issues/2324)).
+- **Uploads**: concurrent duplicate chunk uploads are serialized ([#2316](https://github.com/artifact-keeper/artifact-keeper/issues/2316), [#2348](https://github.com/artifact-keeper/artifact-keeper/issues/2348)).
+- **OCI**: the packages catalog is populated on manifest push ([#2337](https://github.com/artifact-keeper/artifact-keeper/issues/2337)).
+- **Downloads**: presigned-redirect downloads are now recorded in `download_statistics` ([#2349](https://github.com/artifact-keeper/artifact-keeper/issues/2349)).
+- **Migration**: `storage_backend` is persisted for auto-provisioned repos ([#2336](https://github.com/artifact-keeper/artifact-keeper/issues/2336), [#2338](https://github.com/artifact-keeper/artifact-keeper/issues/2338)).
+- **PyPI**: virtual-repo dependency-confusion isolation is now priority-aware ([#2351](https://github.com/artifact-keeper/artifact-keeper/issues/2351)).
+
+## Security
+
+- **Scan-policy validation** ([#2345](https://github.com/artifact-keeper/artifact-keeper/issues/2345)). `max_severity` and `repository_id` are validated before insert.
+
+## Upgrade path
+
+This is a drop-in patch. Pull the new images and restart:
+
+```bash
+docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:1.4.1
+docker pull ghcr.io/artifact-keeper/artifact-keeper-web:1.4.1
+```
+
+Helm and Docker Compose users bump to the v1.4.1-compatible chart or compose file and apply. No configuration changes are required. The web UI, CLI, and native clients work unchanged against a 1.4.1 backend; SDKs are tagged `1.4.1`.
+
+## Support window
+
+- **1.4.x**: active. This patch supersedes 1.4.0.
+- **1.3.x**: maintenance only.
+- **&lt;= 1.2.x**: end of life. Upgrade required.
+
+See [Support Policy](/docs/getting-started/support-policy/) for the full version-support matrix.

--- a/src/content/docs/docs/release-notes/v1-4-2.mdx
+++ b/src/content/docs/docs/release-notes/v1-4-2.mdx
@@ -1,0 +1,35 @@
+---
+title: What's new in 1.4.2
+description: A single Composer metadata fix in the v1.4.2 patch release
+---
+
+v1.4.2 is a focused patch release on top of [1.4.1](/docs/release-notes/v1-4-1/). It fixes Composer downloads from Local/hosted repositories, which previously failed because the package metadata emitted a scheme-less, host-less `dist.url`. There are no breaking changes and no configuration changes.
+
+For the full commit-level changelog, see [the GitHub release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.4.2).
+
+## Fixes
+
+- **Composer Local/hosted repositories emit an absolute `dist.url`** ([#2361](https://github.com/artifact-keeper/artifact-keeper/issues/2361)). Composer metadata (`packages.json`, `p2/`, and the legacy `p/`) previously returned a root-relative `dist.url` (`/composer/{repo}/dist/...`) with no scheme or host, so `composer install` / `composer update` could not download the archive. The Composer handler now threads the external base URL through the `RequestBaseUrl` extractor — honoring `AK_EXTERNAL_URL`, `X-Forwarded-Host`, and `Host` — matching the behavior of npm, Cargo, NuGet, OCI, and Git LFS. `dist.shasum` is also fixed: because Composer verifies it with `sha1_file()` and Artifact Keeper stores SHA-256, the field is now emitted empty, with integrity carried on `dist.reference`. Remote/proxied Composer repos use a separate rewrite path and are unaffected (tracked in [#2370](https://github.com/artifact-keeper/artifact-keeper/issues/2370)). See [Composer / PHP](/docs/guides/composer/).
+
+:::note[Set your external URL]
+For the absolute `dist.url` to be correct behind a reverse proxy, make sure `AK_EXTERNAL_URL` is set (or that `X-Forwarded-Host` / `Host` reflect the externally reachable hostname). See [Reverse Proxy &amp; TLS](/docs/deployment/reverse-proxy/) and [Environment Variables](/docs/reference/environment/).
+:::
+
+## Upgrade path
+
+This is a drop-in patch. Pull the new images and restart:
+
+```bash
+docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:1.4.2
+docker pull ghcr.io/artifact-keeper/artifact-keeper-web:1.4.2
+```
+
+Helm and Docker Compose users bump to the v1.4.2-compatible chart or compose file and apply. The web UI, CLI, and native clients work unchanged against a 1.4.2 backend; SDKs are tagged `1.4.2`.
+
+## Support window
+
+- **1.4.x**: active. This patch supersedes 1.4.1.
+- **1.3.x**: maintenance only.
+- **&lt;= 1.2.x**: end of life. Upgrade required.
+
+See [Support Policy](/docs/getting-started/support-policy/) for the full version-support matrix.

--- a/src/content/docs/docs/release-notes/v1-5-0.mdx
+++ b/src/content/docs/docs/release-notes/v1-5-0.mdx
@@ -1,0 +1,64 @@
+---
+title: What's new in 1.5.0
+description: Headline features, RBAC and SSRF hardening, and upgrade steps for v1.5.0
+---
+
+v1.5.0 is a value-proposition parity release: the enterprise pitch claims are now true in code. This release lands a functional audit trail, per-download attribution, CVE blast-radius analysis, first-class artifact versioning, tightened RBAC, and a coherent connect-time SSRF story — each surfaced in the web UI. This page summarises everything you need to know to upgrade.
+
+For the full commit-level changelog, see [the GitHub release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.5.0).
+
+## Headline changes
+
+- **Functional audit log** ([#2366](https://github.com/artifact-keeper/artifact-keeper/issues/2366)). Security-relevant events — artifact upload/download/delete, user/role/repository CRUD, and permission-denied — are now recorded, with a new admin-only query endpoint `GET /api/v1/admin/audit` (filters and pagination). The response embeds the actor username ([#2392](https://github.com/artifact-keeper/artifact-keeper/issues/2392)), resolving deleted or system actors as null. See [Audit Log](/docs/security/audit-log/).
+- **Per-download IP + user telemetry** ([#2365](https://github.com/artifact-keeper/artifact-keeper/issues/2365)). The real client IP (XFF-aware, trusted-proxy-CIDR gated) and user are recorded for downloads across all 40+ formats into `download_statistics`, with new admin endpoints `GET /api/v1/admin/downloads` (plus `/by-ip/{ip}` and `/by-user/{user_id}`). Recording now covers every content-serving path, including the generic `/artifacts/{path}` and virtual-member-local download branches ([#2394](https://github.com/artifact-keeper/artifact-keeper/issues/2394), [#2398](https://github.com/artifact-keeper/artifact-keeper/issues/2398)). This also closed the [#2023](https://github.com/artifact-keeper/artifact-keeper/issues/2023) trusted-proxy XFF-spoofing gap on the download path. See [Download Telemetry](/docs/monitoring/download-telemetry/).
+- **CVE blast-radius** ([#2364](https://github.com/artifact-keeper/artifact-keeper/issues/2364)). New admin endpoints `GET /api/v1/admin/security/cve/{cve_id}/blast-radius` and `/artifact/{artifact_id}/blast-radius` join CVE findings to the users and IPs that downloaded the vulnerable artifact, plus a bounded per-repository access-scope classification (`public` / `restricted_acl` / `restricted_roles`) that flags "public repo — everyone exposed" without enumerating unbounded populations. See [CVE Blast Radius](/docs/security/blast-radius/).
+- **First-class artifact versioning** ([#2367](https://github.com/artifact-keeper/artifact-keeper/issues/2367)). An opt-in per-repository `versioning_enabled` flag: re-uploading to an existing path now appends an immutable revision instead of overwriting in place. Adds `GET /api/v1/repositories/{key}/versions/{path}`, a `?version=<rev|label>` selector on download and metadata, and `ArtifactVersionResponse` (revision, version_label, uploaded_by). Existing single-copy artifacts and the release-immutability control are unaffected (the flag defaults off). See [Artifact Versioning](/docs/advanced/versioning/).
+- **RPM proxy hardening — Phase 1** ([#2354](https://github.com/artifact-keeper/artifact-keeper/issues/2354)). Connect-time SSRF IP validation, RPM cache classification, content-integrity verification, and mirrorlist rejection for RPM upstream/proxy repositories. See [System Packages](/docs/guides/system-packages/).
+- **Filesystem and incus scans routed through the scanner-adapter** ([#2363](https://github.com/artifact-keeper/artifact-keeper/issues/2363)). Restores first-class Trivy filesystem coverage on the hardened (CLI-free) image by adding a filesystem-scan endpoint to the in-repo scanner-adapter and routing `TrivyFsScanner` / `IncusScanner` through it over HTTP. Adapter-unavailable degrades gracefully to `not_applicable` (Grype still covers), preserving the no-grade-floor contract. See [Vulnerability Scanning](/docs/security/scanning/).
+
+## Changed
+
+- **Repository RBAC and admin-surface authorization tightened** ([#2321](https://github.com/artifact-keeper/artifact-keeper/issues/2321)). The generic-REST and OCI artifact write/delete paths now enforce action-specific permissions — a read-only grantee can no longer write or delete — instead of collapsing read/write/delete into one predicate. The Dependency-Track integration, SBOM CVE-status updates, webhook creation, scan triggering, and cache invalidation are gated to admin / repo-admin, and each new denial emits a `PERMISSION_DENIED` audit event. Promotion and peer-replication paths are unaffected. See [Authentication &amp; RBAC](/docs/advanced/auth/).
+
+## Security
+
+- **Context-aware SSRF gate** ([#2389](https://github.com/artifact-keeper/artifact-keeper/issues/2389), [#2380](https://github.com/artifact-keeper/artifact-keeper/issues/2380)). Operator-configured internal-service clients (scanner-adapter, OpenSCAP, Dependency-Track) reach their private-network endpoints via a dedicated `TrustedInternal` client, and webhook delivery plus SSO/OIDC identity-provider fetches honor their existing `WEBHOOK_ALLOW_PRIVATE_IPS` / `SSO_ALLOW_PRIVATE_IPS` toggles at connect time. Attacker-influenceable upstream/proxy/plugin paths stay fail-closed, and cloud-metadata, loopback, and link-local addresses remain hard-blocked in every context. This resolves the [#2354](https://github.com/artifact-keeper/artifact-keeper/issues/2354) over-block that had blocked private-network scanner adapters and toggle-enabled webhook/SSO targets.
+- **Trivy code-scanning backlog burned down** ([#2391](https://github.com/artifact-keeper/artifact-keeper/issues/2391)). Bundled scanner tools bumped to releases built on a patched Go toolchain (Trivy 0.71.2 → 0.72.0, Grype v0.114.0 → v0.115.0), the scanner-adapter recompiled with Go 1.26.5 and moved to Alpine 3.24, and `docker-publish` now cache-busts the package-refresh stages so OS errata and the Grype DB re-resolve on every publish instead of serving a stale layer. The frozen `:latest-alpine` scheduled scan (a suspended image, the source of 143 of 188 alerts) was removed, and `.trivyignore` refreshed to the current per-CVE residual set.
+
+## Fixed
+
+- **Versions API serializes `uploaded_by`** ([#2397](https://github.com/artifact-keeper/artifact-keeper/issues/2397)) so the version-history UI can attribute each revision.
+- **OpenAPI param de-duplication** on the downloads `by-ip` / `by-user` endpoints ([#2409](https://github.com/artifact-keeper/artifact-keeper/issues/2409)) so the generated SDK builds cleanly across all languages.
+
+:::caution[Upgrade notes]
+Review these behavior changes before upgrading:
+
+- **Audit-log and download-telemetry tables** are populated by the included migrations. No manual action is required, but expect new writes on every download and security-relevant event.
+- **Artifact versioning is opt-in per repository** (`versioning_enabled`, [#2367](https://github.com/artifact-keeper/artifact-keeper/issues/2367)) and defaults off. Turning it on changes re-upload behavior for that repository from overwrite to append-revision. Existing artifacts and the release-immutability control are unaffected.
+- **RBAC is stricter** ([#2321](https://github.com/artifact-keeper/artifact-keeper/issues/2321)). A read-only grantee can no longer write or delete, and several admin surfaces (Dependency-Track, SBOM CVE status, webhook creation, scan triggering, cache invalidation) now require admin / repo-admin. Audit your role grants if automation used a read-only token to write.
+- **SSRF toggles** ([#2380](https://github.com/artifact-keeper/artifact-keeper/issues/2380)). If you previously hit the [#2354](https://github.com/artifact-keeper/artifact-keeper/issues/2354) over-block on private-network scanner adapters or toggle-enabled webhook/SSO targets, this release resolves it. Review `WEBHOOK_ALLOW_PRIVATE_IPS` / `SSO_ALLOW_PRIVATE_IPS` if you rely on private-network targets.
+:::
+
+## Upgrade path
+
+1. **Pull the new images**:
+   ```bash
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:1.5.0
+   docker pull ghcr.io/artifact-keeper/artifact-keeper-web:1.5.0
+   ```
+2. **Run migrations** to create the audit-log, download-telemetry, and versioning tables. No manual data migration is required.
+3. **Audit your RBAC grants** ([#2321](https://github.com/artifact-keeper/artifact-keeper/issues/2321)). Confirm no automation relies on a read-only token to write or delete, and that any workflow that triggers scans, creates webhooks, or invalidates caches runs with admin / repo-admin.
+4. **Review SSRF toggles**. If you depend on private-network scanner adapters, webhooks, or SSO targets, verify `WEBHOOK_ALLOW_PRIVATE_IPS` / `SSO_ALLOW_PRIVATE_IPS` (and `AK_SSRF_ALLOW_PRIVATE_CIDRS` where applicable) are set. See [Environment Variables](/docs/reference/environment/).
+5. **Enable versioning where you want it**. Set `versioning_enabled` on the repositories that should retain revision history — it is off by default.
+6. **Helm / Docker Compose**: bump to the v1.5.0-compatible chart or compose file and apply.
+7. **Verify**: query `GET /api/v1/admin/audit`, confirm downloads appear in `GET /api/v1/admin/downloads`, and confirm scans complete (Trivy filesystem coverage restored, or `not_applicable` where the adapter is unavailable).
+
+The web UI, CLI, and native clients work unchanged against a 1.5.0 backend. SDKs published to npm, Maven, PyPI, crates.io, and SPM are tagged `1.5.0`.
+
+## Support window
+
+- **1.5.x**: active. Bug fixes, security patches, and feature work all land here.
+- **1.4.x**: maintenance only. Security backports until the next minor ships.
+- **&lt;= 1.3.x**: end of life. Upgrade required.
+
+See [Support Policy](/docs/getting-started/support-policy/) for the full version-support matrix.

--- a/src/content/docs/docs/release-notes/v1-5-1.mdx
+++ b/src/content/docs/docs/release-notes/v1-5-1.mdx
@@ -1,0 +1,50 @@
+---
+title: What's new in 1.5.1
+description: Eleven validated bug and security fixes in the v1.5.1 patch release
+---
+
+v1.5.1 is a patch release on top of [1.5.0](/docs/release-notes/v1-5-0/). It ships eleven validated bug and security fixes across audit correlation, observability noise, virtual-repository resolution and scanning, the Composer and OCI/npm surfaces, and the SSRF trust model — each replicated, fixed, and re-verified on an isolated stack. There are no breaking changes.
+
+For the full commit-level changelog, see [the GitHub release notes](https://github.com/artifact-keeper/artifact-keeper/releases/tag/v1.5.1).
+
+## Added
+
+- **Server-side npm scope policy for virtual repositories** ([#2327](https://github.com/artifact-keeper/artifact-keeper/issues/2327)). An optional, admin-defined per-repository scope allow-list (`npm_allowed_scopes` / `npm_allow_unscoped`, stored in `repository_config`), with new admin-only, Remote-only `PUT` / `GET /api/v1/repositories/{key}/npm-scope-policy` endpoints. npm virtual resolution now skips a policy-mismatched Remote member before querying it, so a broad linked remote can be restricted to specific scopes. Default behavior is unchanged (no policy ⇒ allow all); tarball-path, direct-remote, glob patterns, and the web UI are tracked as a follow-up ([#2424](https://github.com/artifact-keeper/artifact-keeper/issues/2424)). See [npm](/docs/guides/npm/).
+
+## Security
+
+- **CI-OIDC identity-provider fetches are now context-aware** ([#2405](https://github.com/artifact-keeper/artifact-keeper/issues/2405)). The CI-OIDC discovery/JWKS fetches use the SSO trust-class client, so a CI-OIDC identity provider on a private address is reachable when the operator opts in via the existing `SSO_ALLOW_PRIVATE_IPS` / `AK_SSRF_ALLOW_PRIVATE_CIDRS` knobs — completing the [#2380](https://github.com/artifact-keeper/artifact-keeper/issues/2380) / [#2389](https://github.com/artifact-keeper/artifact-keeper/issues/2389) context-aware SSRF work for the last identity-provider surface still pinned to the fail-closed upstream default. With no toggle set, behavior is unchanged (fail-closed), and cloud-metadata, loopback, and link-local addresses remain hard-blocked regardless of any toggle.
+- **OCI `/v2/token` exchange enforces API-token scope** ([#2290](https://github.com/artifact-keeper/artifact-keeper/issues/2290)). The minted OCI bearer now carries the requesting token's `allowed_repo_ids`, and a repo-scope check is applied on the OCI write and scan-pull paths ahead of the admin/public bypass — bringing OCI to parity with the REST token-scope gate.
+- **Vulnerable transitive crates bumped** ([#2272](https://github.com/artifact-keeper/artifact-keeper/issues/2272)). openssl 0.10.78→0.10.80, tar 0.4.45→0.4.46, opentelemetry_sdk 0.28→0.32 (paired set), cmov 0.5.2→0.5.4, and rand patch bumps — clearing the Trivy/RUSTSEC advisories (9→0) with no source changes.
+
+## Fixed
+
+- **Audit events preserve the request correlation ID** ([#2414](https://github.com/artifact-keeper/artifact-keeper/issues/2414)) instead of generating an unrelated one, so an action and its audit record can be tied together. See [Audit Log](/docs/security/audit-log/).
+- **Admin Settings environment badge is sourced from runtime config** ([#2325](https://github.com/artifact-keeper/artifact-keeper/issues/2325)) rather than always showing "Production".
+- **Observability noise reduced** ([#2308](https://github.com/artifact-keeper/artifact-keeper/issues/2308)). The duplicate `http_request` span and the blanket ERROR-level logging that misclassified routine 4xx responses as failures are removed.
+- **Maven virtual downloads consult Remote members** ([#2328](https://github.com/artifact-keeper/artifact-keeper/issues/2328), regression of #1562). A remote-only artifact with a valid cached copy is served from a virtual repository instead of 404ing.
+- **Composer remote/proxied metadata emits an absolute `dist.url`** ([#2370](https://github.com/artifact-keeper/artifact-keeper/issues/2370)). The #1652-rewritten metadata is now `RequestBaseUrl`-prefixed so Composer clients fetch through the proxy cache instead of falling back to a source clone. See [Composer / PHP](/docs/guides/composer/).
+- **Repository-wide scans enumerate virtual-repository members** ([#2228](https://github.com/artifact-keeper/artifact-keeper/issues/2228)). Triggering a scan on a virtual repository now resolves its member repos (recursively) and enqueues their artifacts instead of reporting "0 artifacts". The local-repository path is unchanged. See [Vulnerability Scanning](/docs/security/scanning/).
+
+:::note[npm scope policy is opt-in]
+The new npm scope policy ([#2327](https://github.com/artifact-keeper/artifact-keeper/issues/2327)) defaults to allow-all — no behavior changes until an admin sets `npm_allowed_scopes` / `npm_allow_unscoped` on a Remote repository. The context-aware CI-OIDC SSRF change ([#2405](https://github.com/artifact-keeper/artifact-keeper/issues/2405)) is likewise fail-closed unless you have already opted in via `SSO_ALLOW_PRIVATE_IPS` / `AK_SSRF_ALLOW_PRIVATE_CIDRS`.
+:::
+
+## Upgrade path
+
+This is a drop-in patch. Pull the new images and restart:
+
+```bash
+docker pull ghcr.io/artifact-keeper/artifact-keeper-backend:1.5.1
+docker pull ghcr.io/artifact-keeper/artifact-keeper-web:1.5.1
+```
+
+Helm and Docker Compose users bump to the v1.5.1-compatible chart or compose file and apply. No configuration changes are required. The web UI, CLI, and native clients work unchanged against a 1.5.1 backend; SDKs are tagged `1.5.1`.
+
+## Support window
+
+- **1.5.x**: active. This patch supersedes 1.5.0.
+- **1.4.x**: maintenance only.
+- **&lt;= 1.3.x**: end of life. Upgrade required.
+
+See [Support Policy](/docs/getting-started/support-policy/) for the full version-support matrix.


### PR DESCRIPTION
## Summary

Adds the missing release-notes pages for every release since v1.2.0. Only `release-notes/v1-2-0.mdx` existed; this PR fills the gap up through the latest patch.

New pages (mirroring the exact structure, frontmatter, and voice of the existing `v1-2-0.mdx`):

- `release-notes/v1-3-0.mdx` — streaming trilogy, auth/audit epic phase 1, npm SWR packument cache, fail-closed-on-scan-error, `AK_ENFORCE_HTTPS`
- `release-notes/v1-4-0.mdx` — auth/SSO epic, keyless CI-OIDC token exchange, OIDC legacy-RSA flag, `/health` + gRPC-reflection gating, dedicated login rate limit, PyPI `upstream_index_path`, Dart Pub
- `release-notes/v1-4-1.mdx` — OpenAPI/runtime alignment, authenticated-user public-repo read baseline, assorted fixes
- `release-notes/v1-4-2.mdx` — Composer absolute `dist.url` (#2361)
- `release-notes/v1-5-0.mdx` — value-prop parity epic: audit log, download telemetry, CVE blast-radius, artifact versioning, RBAC hardening, RPM Phase-1, scanner-adapter fs/incus scans, context-aware SSRF, Trivy burndown (cross-links the audit-log, download-telemetry, blast-radius, and versioning feature pages)
- `release-notes/v1-5-1.mdx` — the 11-fix patch slate

## Content source

Summarized from the backend `CHANGELOG.md` sections and the polished GitHub release bodies — nothing invented. Behavior changes and new default-off flags (fail-closed scanning, `AK_ENFORCE_HTTPS`, `allow_legacy_rsa_keys`, `/health`/gRPC gating, `versioning_enabled`, RBAC tightening, `WEBHOOK/SSO_ALLOW_PRIVATE_IPS`, npm scope policy) are called out in Upgrade Notes admonitions.

## Sidebar

All six pages registered in the `astro.config.mjs` Release Notes section, newest first.

## Validation

`npm ci && npm run build` passes — 87 pages built, all six new pages included.