### PR TITLE
docs: v1.3–v1.5 feature deltas across scanning/system-packages/monitoring/architecture/format guides (refs #54)

### DIFF
--- a/src/content/docs/docs/advanced/remote-virtual.mdx
+++ b/src/content/docs/docs/advanced/remote-virtual.mdx
@@ -173,6 +173,10 @@ Members with a **lower priority number** are checked first. If a package is foun
 
 Like remote repos, virtual repositories are **read-only**. Uploads must target a specific local repository directly.
 
+### npm scope policy (v1.5.1)
+
+npm virtual repositories support an optional, admin-defined **scope allow-list** (#2327): a Remote member whose scope does not match the policy is skipped before it is ever queried, so a broad linked upstream (e.g. `registry.npmjs.org`) can be restricted to specific `@scope` names. It is configured per repository (`npm_allowed_scopes` / `npm_allow_unscoped`) via the admin-only, Remote-only `PUT`/`GET /api/v1/repositories/{key}/npm-scope-policy` endpoints. The default is unchanged — with no policy, all scopes are allowed. For scoped-package usage on the client side, see the [npm Registry Guide](/docs/guides/npm).
+
 ## Client Configuration
 
 Once your repositories are set up, point your package manager at the virtual (or remote) repository URL. The URL pattern is the same as for local repositories — the format handler is determined by the repository's configured format.

--- a/src/content/docs/docs/advanced/storage.mdx
+++ b/src/content/docs/docs/advanced/storage.mdx
@@ -5,6 +5,10 @@ description: "Filesystem, S3, Azure Blob, and Google Cloud Storage backends for 
 
 Artifact Keeper supports multiple storage backends to accommodate different deployment scenarios and scale requirements. You can configure a default backend for the entire instance, or assign different backends to individual repositories.
 
+:::note[End-to-end streaming (v1.3.0)]
+As of v1.3.0, artifact data streams end-to-end through the storage backend for both uploads and pull-through (proxy/remote) downloads, rather than being buffered in memory. Backends must implement `StorageBackend::put_stream` — it is a required trait method, so a custom backend cannot silently inherit in-memory buffering. This keeps memory use bounded regardless of artifact size.
+:::
+
 ## Storage Backend Types
 
 ### Filesystem Storage
@@ -605,6 +609,8 @@ Artifact metadata is stored in PostgreSQL, not in the storage backend. The stora
 ## Garbage Collection
 
 Remove orphaned artifacts that are no longer referenced in the database.
+
+Since v1.3.0, blob GC is a two-phase **mark-and-sweep**: an orphaned blob is first marked `pending_delete` in the database, and only removed from storage on a subsequent sweep. The delete itself is idempotent, so a retried or overlapping GC pass is safe and a blob re-referenced between phases is spared.
 
 ### Manual Cleanup
 

--- a/src/content/docs/docs/getting-started/architecture.mdx
+++ b/src/content/docs/docs/getting-started/architecture.mdx
@@ -134,6 +134,8 @@ StorageBackend trait
 
 Artifacts are stored by their SHA-256 hash, enabling automatic deduplication across repositories. The backend chosen via `STORAGE_BACKEND` env var (`filesystem` or `s3`).
 
+As of v1.3.0, artifact data streams end-to-end through the storage backend — both uploads and pull-through (proxy/remote) downloads — instead of being buffered in memory. `StorageBackend::put_stream` is a required trait method, so a custom backend cannot silently fall back to in-memory buffering. Blob garbage collection is a two-phase mark-and-sweep: orphaned blobs are first marked `pending_delete`, then swept in a later idempotent pass.
+
 ### Database
 
 PostgreSQL 16 with 33 migrations covering:

--- a/src/content/docs/docs/guides/composer.mdx
+++ b/src/content/docs/docs/guides/composer.mdx
@@ -227,6 +227,10 @@ rm "$ARCHIVE"
 
 ## Installing Packages
 
+:::note[Absolute `dist.url` behind a reverse proxy]
+Composer metadata for local/hosted repositories emits an **absolute** `dist.url` (v1.4.2, #2361) so `composer install`/`update` can download the archive directly. The external base URL is derived from the incoming request — honoring `AK_EXTERNAL_URL`, then `X-Forwarded-Host`, then the `Host` header — matching the npm/cargo/nuget/oci/gitlfs handlers. If you run Artifact Keeper behind a reverse proxy, set `AK_EXTERNAL_URL` (or forward `X-Forwarded-Host`) so the emitted URLs point at the public address. Remote/proxied Composer repositories got the same absolute-URL rewrite in v1.5.1 (#2370).
+:::
+
 ### Install Package
 
 ```bash

--- a/src/content/docs/docs/guides/pypi.mdx
+++ b/src/content/docs/docs/guides/pypi.mdx
@@ -645,6 +645,10 @@ trusted-host = localhost
 
 Internal packages resolve first, public packages are transparently cached from PyPI.
 
+:::note[Dependency-confusion isolation is priority-aware]
+As of v1.4.x (#2311, #2351), a name owned by a higher-priority **local** member suppresses the same name on a lower-priority **remote** member: pip is never offered the public package for a name your own repository already publishes. This closes the dependency-confusion window regardless of upstream version numbers — put your internal repo at the lower `priority` value (checked first), as above.
+:::
+
 For full details on cache TTL configuration, priority ordering, and monitoring, see the [Remote & Virtual Repositories](/docs/advanced/remote-virtual) guide.
 
 ## See Also

--- a/src/content/docs/docs/guides/system-packages.mdx
+++ b/src/content/docs/docs/guides/system-packages.mdx
@@ -100,6 +100,21 @@ echo "deb [trusted=yes] http://localhost:8080/debian/debian-bullseye main" | \
 
 Artifact Keeper provides RPM repository support compatible with `yum`, `dnf`, and `zypper`.
 
+:::note[RPM proxy hardening (v1.5.0)]
+RPM remote/proxy repositories carry Phase-1 SSRF and integrity hardening (#2354):
+
+- **Connect-time private-IP validation** on RPM upstreams — the upstream is
+  re-validated against the SSRF policy at connect time, not just at creation.
+- **RPM cache classification** distinguishes cacheable content from metadata.
+- **Content-integrity verification** of fetched RPM content.
+- **Mirrorlist/metalink rejection** — an RPM remote upstream must be a concrete
+  `baseurl` (e.g. `.../BaseOS/x86_64/os/`), not a `mirrorlist`/`metalink` URL.
+
+The standard SSRF toggles apply: private-network upstreams require explicitly
+opting in via `AK_SSRF_ALLOW_PRIVATE_CIDRS`, and cloud-metadata, loopback, and
+link-local addresses stay blocked regardless.
+:::
+
 ### Endpoint
 
 ```
@@ -648,6 +663,13 @@ Always test packages in a staging environment:
 Use Artifact Keeper as a pull-through cache for public system package repositories or aggregate multiple package sources.
 
 Remote proxy and virtual repository support is available for all system package formats: RPM (yum/dnf), Debian (apt), and Alpine (apk).
+
+For RPM specifically, remote/proxy repositories are hardened as of v1.5.0
+(#2354): connect-time private-IP SSRF validation, RPM cache classification,
+content-integrity verification of fetched content, and rejection of
+`mirrorlist`/`metalink` upstreams (point the upstream at a concrete resolved
+`baseurl` instead). Reaching a private-network upstream still requires opting in
+via `AK_SSRF_ALLOW_PRIVATE_CIDRS`.
 
 ### Pull-Through Cache Examples
 

--- a/src/content/docs/docs/monitoring/health-checks.mdx
+++ b/src/content/docs/docs/monitoring/health-checks.mdx
@@ -81,6 +81,16 @@ Returns `200 OK` when all services are healthy, or `503 Service Unavailable` whe
 Do not use `/health` as a Kubernetes liveness probe. If an external service like Trivy or OpenSearch goes down, the `/health` endpoint returns 503, which would cause Kubernetes to restart your backend pods, even though the backend itself is functioning correctly. This creates cascading failures. Use `/livez` for liveness instead.
 :::
 
+### Detailed output is off by default (`EXPOSE_DETAILED_HEALTH`)
+
+Since v1.4.0, the operator-only detail in the `/health` response is **suppressed by default** to close a build/topology information leak (#2253). By default the probe stays minimal — overall `status`, `version`, and the per-service `checks`. The extra fields that let an anonymous caller fingerprint the exact build and observe live pool pressure are omitted:
+
+- `commit` — the exact git commit SHA
+- the prerelease / `dirty` build flag
+- `db_pool` — live connection-pool internals (`active`/`idle`/`max`/`size`)
+
+To surface these for debugging, set `EXPOSE_DETAILED_HEALTH=true` explicitly. Administrators can still read pool detail from the authenticated `/metrics` and memory-stats endpoints regardless of this flag.
+
 ## Response Examples
 
 ### Liveness probe
@@ -164,6 +174,8 @@ curl -s http://localhost:8080/health | jq .
   }
 }
 ```
+
+The `db_pool` block (and the `commit`/`dirty` build fields) shown above appear only when `EXPOSE_DETAILED_HEALTH=true`. With the default off, the response is limited to `status`, `version`, and `checks`.
 
 ## Kubernetes Configuration
 

--- a/src/content/docs/docs/monitoring/metrics.mdx
+++ b/src/content/docs/docs/monitoring/metrics.mdx
@@ -37,6 +37,8 @@ These metrics track all inbound HTTP traffic to the backend API.
 
 :::tip
 Paths are normalized to prevent high-cardinality label explosion. UUIDs are replaced with `:id` and numeric identifiers are replaced with `:id`. For example, `/api/v1/repositories/550e8400-e29b-41d4-a716-446655440000/artifacts` becomes `/api/v1/repositories/:id/artifacts`.
+
+Since v1.3.0, any request that does not match a known route also collapses to a single placeholder `path` label of `unmatched` (#2217). Without this, a scanner probing thousands of nonexistent URLs would mint a new time series per path and blow up label cardinality; instead every unrouted request shares one series.
 :::
 
 ### Example Queries

--- a/src/content/docs/docs/security/scanning.mdx
+++ b/src/content/docs/docs/security/scanning.mdx
@@ -117,7 +117,13 @@ Supported artifact types:
 Configure Trivy integration:
 
 ```bash
-# Required: Trivy server URL
+# Scanner-adapter URL (recommended). Routes filesystem/incus and
+# container-image scans over HTTP through the in-repo scanner-adapter,
+# so no trivy CLI binary is required in the image.
+TRIVY_ADAPTER_URL=http://trivy:8090
+
+# Legacy Trivy server URL. Only consulted when TRIVY_ADAPTER_URL is unset;
+# makes the filesystem/incus scanners spawn a bundled local trivy CLI.
 TRIVY_URL=http://trivy:8080
 
 # Optional: Trivy authentication
@@ -128,6 +134,20 @@ SCAN_ON_UPLOAD=true
 SCAN_TIMEOUT=300
 SCAN_CACHE_TTL=3600
 ```
+
+#### Scanner-adapter routing (hardened image)
+
+Since v1.5.0, filesystem and incus (rootfs) scans route through the in-repo
+scanner-adapter over HTTP. When `TRIVY_ADAPTER_URL` is set, `TrivyFsScanner`
+and `IncusScanner` upload the prepared workspace to the adapter's filesystem
+endpoint instead of shelling out to a local `trivy` binary — restoring
+first-class Trivy filesystem coverage on the hardened, CLI-free image (#2363).
+The adapter drives container-image scans over the same URL.
+
+If the adapter is unavailable, filesystem/incus scans degrade gracefully to
+`not_applicable` rather than failing the whole scan — Grype still covers those
+artifacts, preserving the no-grade-floor contract. The tarred-workspace upload
+budget is tunable via `MAX_FS_SCAN_UPLOAD_BYTES` (default 64 GiB).
 
 ### Database Configuration
 
@@ -240,6 +260,19 @@ Content-Type: application/json
   "scanner": "trivy"
 }
 ```
+
+### API Error Responses
+
+The scan endpoints return explicit error statuses rather than a misleading
+empty payload:
+
+| Status | When | Body |
+|--------|------|------|
+| `503 Service Unavailable` | No scanner is configured (`TRIVY_ADAPTER_URL`/`TRIVY_URL` unset) when a scan is requested | `Scanner service not configured` |
+| `404 Not Found` | The requested `scan_id` (or its findings) does not exist | `Scan not found` |
+
+A `503` here is an operational signal ("scanner not configured"), not a server
+bug — configure a scanner backend and retry.
 
 ## UI Integration
 
@@ -484,6 +517,15 @@ Response:
 ```
 
 ## Troubleshooting
+
+### Fail-Closed on Scan Error
+
+Since v1.3.0, a scan that errors **fails closed**: the artifact is no longer
+reported clean when the scanner itself fails (#2240). An errored scan is
+recorded as a failure rather than an empty/clean result, so security policies
+that block on scan status will not be satisfied by a scanner outage. (A scan
+that runs successfully against an unscannable artifact type still records
+`not_applicable` — that is distinct from an error.)
 
 ### Scan Failures
 


### PR DESCRIPTION
Wave 4 polish pass: brings several existing docs pages up to date with v1.3–v1.5 behavior. Edits to existing pages only — no new pages, no sidebar changes. Every claim verified against the backend `CHANGELOG.md` ([1.3.0]–[1.5.1]) and source.

## Pages touched
- **security/scanning.mdx** — filesystem/incus scans now route through the in-repo scanner-adapter over HTTP (`TRIVY_ADAPTER_URL`; adapter-unavailable degrades to `not_applicable`, Grype still covers) — v1.5.0 #2363; scan errors now **fail closed** (no longer report clean) — v1.3.0 #2240; new "API Error Responses" subsection (503 "Scanner service not configured", 404 unknown `scan_id`). Addresses the scanner-errors part of #63.
- **guides/system-packages.mdx** — RPM proxy Phase-1 hardening in the RPM/YUM/DNF and Remote/Virtual sections: connect-time private-IP SSRF validation, RPM cache classification, content-integrity verification, mirrorlist/metalink rejection; SSRF toggles apply — v1.5.0 #2354.
- **monitoring/health-checks.mdx** — `EXPOSE_DETAILED_HEALTH`: detailed `/health` output (commit SHA, dirty flag, `db_pool`) is off by default to close a build/topology info leak; enable explicitly for debugging — v1.4.0 #2253.
- **monitoring/metrics.mdx** — unmatched HTTP request paths collapse to a single `unmatched` placeholder label to prevent scanner-driven cardinality explosion — v1.3.0 #2217.
- **getting-started/architecture.mdx** + **advanced/storage.mdx** — end-to-end streaming (uploads + pull-through downloads), the `StorageBackend::put_stream` requirement for custom backends, and two-phase mark-and-sweep blob GC — v1.3.0.
- **guides/pypi.mdx** — virtual-repo dependency-confusion isolation is now priority-aware (a local member owning a name suppresses the remote) — v1.4.x #2311/#2351.
- **guides/composer.mdx** — local/hosted metadata emits an absolute `dist.url` (RequestBaseUrl / `AK_EXTERNAL_URL` / `X-Forwarded-Host`) — v1.4.2 #2361; remote/proxied got the same in v1.5.1 #2370.
- **advanced/remote-virtual.mdx** — note + cross-link that npm virtual repos support an admin scope-policy allow-list — v1.5.1 #2327.

## Validation
`npm ci && npm run build` passes (82 pages built).

refs #54