### PR TITLE
docs: correct remaining Meilisearch references to OpenSearch

### DIFF
--- a/src/components/landing/Footer.astro
+++ b/src/components/landing/Footer.astro
@@ -26,7 +26,7 @@ const year = new Date().getFullYear();
 
     <p class="text-sm mb-2">MIT Licensed</p>
     <p class="text-xs text-gray-500 mb-1">Built with Rust and TypeScript</p>
-    <p class="text-xs text-gray-600 mb-1">Security scanning by <a href="https://trivy.dev/" class="hover:text-gray-400">Trivy</a> &amp; <a href="https://dependencytrack.org/" class="hover:text-gray-400">OWASP Dependency-Track</a>. Search by <a href="https://www.meilisearch.com/" class="hover:text-gray-400">Meilisearch</a>. Database by <a href="https://www.postgresql.org/" class="hover:text-gray-400">PostgreSQL</a>.</p>
+    <p class="text-xs text-gray-600 mb-1">Security scanning by <a href="https://trivy.dev/" class="hover:text-gray-400">Trivy</a> &amp; <a href="https://dependencytrack.org/" class="hover:text-gray-400">OWASP Dependency-Track</a>. Search by <a href="https://opensearch.org/" class="hover:text-gray-400">OpenSearch</a>. Database by <a href="https://www.postgresql.org/" class="hover:text-gray-400">PostgreSQL</a>.</p>
     <p class="text-xs text-gray-500">&copy; {year} Artifact Keeper. All rights reserved.</p>
     <p class="text-xs text-gray-600 mt-3">
       "JFrog" and "Artifactory" are trademarks of JFrog Ltd. Artifact Keeper is not affiliated with or endorsed by JFrog.

--- a/src/content/docs/docs/getting-started/architecture.mdx
+++ b/src/content/docs/docs/getting-started/architecture.mdx
@@ -47,7 +47,7 @@ graph LR
 | **OpenSearch** | Full-text search across artifacts and repos | Optional |
 | **Trivy** | Vulnerability scanning for uploaded artifacts | Optional |
 
-OpenSearch, Trivy, and Grype degrade gracefully. The system works without them, just without search or scanning.
+OpenSearch, Trivy, and Grype degrade gracefully. The system works without them. Full-text search still runs on PostgreSQL when OpenSearch is not configured; OpenSearch adds the enhanced layer (typeahead, fuzzy matching, and global search across repositories). Without Trivy or Grype you lose vulnerability scanning.
 
 ## Backend Layers
 

--- a/src/content/docs/docs/reference/environment.mdx
+++ b/src/content/docs/docs/reference/environment.mdx
@@ -407,11 +407,11 @@ Email delivery is disabled when `SMTP_HOST` is not set. Used for password expira
 
 ## Search (OpenSearch)
 
-Search is powered by [OpenSearch](https://opensearch.org/). When `OPENSEARCH_URL` is set, the backend indexes artifacts for full-text search. On first boot the backend auto-reindexes from PostgreSQL, so no data migration step is required. Read by the **backend** process.
+The enhanced search layer is powered by [OpenSearch](https://opensearch.org/). OpenSearch is optional: full-text search always works on PostgreSQL, and setting `OPENSEARCH_URL` adds typeahead, fuzzy matching, and global search across repositories. When `OPENSEARCH_URL` is set, the backend indexes artifacts into OpenSearch; on first boot it auto-reindexes from PostgreSQL, so no data migration step is required. Read by the **backend** process.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `OPENSEARCH_URL` | No | - | OpenSearch server URL (e.g., `https://opensearch:9200`). Search is disabled when unset. |
+| `OPENSEARCH_URL` | No | - | OpenSearch server URL (e.g., `https://opensearch:9200`). When unset, the enhanced search layer is disabled and search falls back to PostgreSQL full-text. |
 | `OPENSEARCH_USERNAME` | No | - | OpenSearch username (required when the security plugin is enabled, which is the default) |
 | `OPENSEARCH_PASSWORD` | No | - | OpenSearch password |
 | `OPENSEARCH_ALLOW_INVALID_CERTS` | No | `false` | Skip TLS certificate verification. Only set to `true` for self-signed dev clusters. |


### PR DESCRIPTION
## Summary

The search backend moved from Meilisearch to OpenSearch in 1.2 and most docs were already updated. This cleans up the last stale surfaces and corrects two statements that oversold OpenSearch as mandatory:

- `src/components/landing/Footer.astro`: footer credit now reads "Search by OpenSearch" and links to opensearch.org.
- `src/content/docs/docs/getting-started/architecture.mdx`: clarifies that full-text search still runs on PostgreSQL when OpenSearch is absent; OpenSearch adds the enhanced layer (typeahead, fuzzy matching, global search across repositories).
- `src/content/docs/docs/reference/environment.mdx`: `OPENSEARCH_URL` description now says that when unset, search falls back to PostgreSQL full-text rather than being disabled.

Verified against the backend ground truth: `search_service.rs` runs PostgreSQL `to_tsvector`/`to_tsquery` full-text search independently of `opensearch_service.rs`, so search works without OpenSearch. The version banners, migration guide, release notes, and Helm upgrade section keep their intentional historical Meilisearch references.

Closes #89

## Test Checklist
- [x] `npm run build` passes (88 pages built)
- [ ] Verified page renders correctly locally (`npm run dev`)
- [x] Links are valid (no broken links)
- [ ] Images load correctly
- [x] No regressions on other pages