### PR TITLE
docs: rewrite backup page to match implemented behaviour

### DIFF
--- a/src/content/docs/docs/advanced/backup.mdx
+++ b/src/content/docs/docs/advanced/backup.mdx
@@ -1,537 +1,321 @@
 ---
 title: "Backup & Recovery"
-description: "Built-in backup system for database and artifacts with scheduled backups and restore capabilities"
+description: "Built-in backup and restore for core metadata tables and artifact blobs"
 ---
 
-Artifact Keeper includes a comprehensive backup and recovery system to protect your registry data and artifacts.
+Artifact Keeper includes a built-in backup system that captures core metadata
+tables and artifact blobs into a single archive, and a restore path that reads
+that archive back.
 
-## Backup Components
+Read the scope section below before relying on it. A backup is not a full
+instance snapshot, and restore is additive rather than destructive. Both
+behaviours surprise people who expect `pg_dump` semantics.
 
-A complete backup includes:
+## Scope
 
-1. **Database backup**: PostgreSQL dump of all metadata, users, permissions, and configuration
-2. **Artifact storage**: All artifact files from the storage backend
-3. **System configuration**: Environment settings and plugin configurations
+### What a backup contains
 
-## Creating Backups
+- **Eight metadata tables**, each exported as JSON (not a PostgreSQL dump):
+  `users`, `repositories`, `artifacts`, `download_statistics`, `api_tokens`,
+  `roles`, `user_roles`, `permission_grants`.
+- **Artifact blobs**, fetched from the storage backend, one archive entry per
+  artifact.
+- **A manifest** describing the archive.
 
-### Manual Backup via API
+### What a backup does not contain
 
-```bash
-curl -X POST https://registry.example.com/api/v1/admin/backups \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "description": "Pre-upgrade backup",
-    "include_artifacts": true,
-    "compression": "gzip"
-  }'
-```
+This list matters more than the one above:
 
-Response:
+- No audit log, webhooks, plugins, or system settings.
+- No security scan results, findings, or SBOMs.
+- No signing keys or repository signing configuration.
+- No repository configuration beyond the `repositories` row itself.
+- No environment or application configuration files.
+- No PostgreSQL schema. Restore targets an existing, migrated database.
 
-```json
-{
-  "backup_id": "backup-123",
-  "status": "in_progress",
-  "started_at": "2026-02-01T12:00:00Z",
-  "description": "Pre-upgrade backup"
-}
-```
+A backup is therefore useful for recovering metadata and artifact content into
+a working instance. It is not sufficient to rebuild an instance from nothing,
+and it is not a substitute for database-level backups of the PostgreSQL
+instance itself. For full disaster recovery, take a real `pg_dump` or use your
+platform's database snapshot mechanism alongside this feature.
 
-### Manual Backup via CLI
+## Creating a backup
 
-```bash
-# Full backup
-artifact-keeper backup create \
-  --output /backups/full-backup-2026-02-01.tar.gz \
-  --compression gzip
-
-# Database only
-artifact-keeper backup create \
-  --database-only \
-  --output /backups/db-backup-2026-02-01.sql.gz
-
-# Artifacts only
-artifact-keeper backup create \
-  --artifacts-only \
-  --output /backups/artifacts-backup-2026-02-01.tar.gz
-```
-
-## Scheduled Backups
-
-### Configuration
-
-Enable automatic scheduled backups:
-
-```bash
-# Enable scheduled backups
-BACKUP_ENABLED=true
-
-# Backup schedule (cron format)
-BACKUP_SCHEDULE="0 2 * * *"  # Daily at 2 AM
-
-# Backup retention
-BACKUP_RETENTION_DAYS=30
-
-# Backup destination
-BACKUP_PATH=/var/backups/artifact-keeper
-
-# Include artifacts in scheduled backups
-BACKUP_INCLUDE_ARTIFACTS=true
-
-# Compression method
-BACKUP_COMPRESSION=gzip  # or 'zstd', 'none'
-```
-
-### Backup Retention Policy
-
-```bash
-# Keep daily backups for 7 days
-BACKUP_RETENTION_DAILY=7
-
-# Keep weekly backups for 4 weeks
-BACKUP_RETENTION_WEEKLY=4
-
-# Keep monthly backups for 12 months
-BACKUP_RETENTION_MONTHLY=12
-```
-
-Artifact Keeper automatically manages backup rotation based on these policies.
-
-## Backup Storage
-
-### Local Filesystem
-
-Default storage location:
-
-```bash
-BACKUP_PATH=/var/backups/artifact-keeper
-```
-
-Ensure sufficient disk space:
-
-```bash
-df -h /var/backups
-```
-
-### Remote Storage (S3)
-
-Store backups in S3-compatible storage:
-
-```bash
-BACKUP_STORAGE=s3
-BACKUP_S3_BUCKET=artifact-keeper-backups
-BACKUP_S3_REGION=us-east-1
-BACKUP_S3_PREFIX=backups/
-BACKUP_S3_ACCESS_KEY_ID=your-access-key
-BACKUP_S3_SECRET_ACCESS_KEY=your-secret-key
-```
-
-### Network Storage
-
-Use NFS or other network-attached storage:
-
-```bash
-# Mount NFS share
-sudo mount -t nfs backup-server:/backups /mnt/backups
-
-# Configure backup path
-BACKUP_PATH=/mnt/backups/artifact-keeper
-```
-
-## Backup Structure
-
-### Backup Archive Contents
-
-```text
-backup-2026-02-01-120000/
-├── metadata.json          # Backup metadata
-├── database/
-│   └── dump.sql.gz       # PostgreSQL dump
-├── artifacts/
-│   └── storage.tar.gz    # Artifact files
-├── config/
-│   ├── environment.env   # Environment variables
-│   └── plugins/          # Plugin configurations
-└── checksum.sha256       # Integrity verification
-```
-
-### Metadata File
-
-```json
-{
-  "backup_id": "backup-123",
-  "created_at": "2026-02-01T12:00:00Z",
-  "version": "1.0.0",
-  "components": {
-    "database": true,
-    "artifacts": true,
-    "config": true
-  },
-  "statistics": {
-    "database_size_mb": 245,
-    "artifacts_count": 15234,
-    "artifacts_size_mb": 125678,
-    "total_size_mb": 125923
-  },
-  "compression": "gzip",
-  "encryption": false
-}
-```
-
-## Restoring from Backup
+Creating and running a backup are two steps: `POST /backups` registers the
+backup record, and `POST /backups/{id}/execute` performs the work.
 
 ### Via API
 
 ```bash
-curl -X POST https://registry.example.com/api/v1/admin/backups/backup-123/restore \
+# 1. Create the backup record
+curl -X POST https://registry.example.com/api/v1/admin/backups \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "restore_database": true,
-    "restore_artifacts": true,
-    "restore_config": true
-  }'
+  -d '{"type": "full"}'
 ```
+
+Optional fields on the create request:
+
+| Field | Meaning |
+|---|---|
+| `type` | `full`, `incremental`, or `metadata`. See the note below. |
+| `repository_ids` | Allowlist of repository ids to include. Omit for all repositories. |
+| `exclude_repositories` | Repository ids to exclude. Useful for keeping large repositories out of a transfer archive. |
+
+```bash
+# 2. Execute it
+curl -X POST https://registry.example.com/api/v1/admin/backups/$BACKUP_ID/execute \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+The execute call is synchronous. It returns once the archive has been built and
+written, so expect the request to stay open for the duration on large
+registries.
+
+:::caution[Backup type is not yet implemented]
+`type` is accepted, stored, and reported back, but all three values currently
+produce an identical full archive. Incremental backup support is tracked in
+[#2788](https://github.com/artifact-keeper/artifact-keeper/issues/2788).
+:::
+
+`repository_ids` and `exclude_repositories` scope **artifact blobs only**. The
+metadata tables are always exported in full, so a repository-scoped backup is
+smaller but is not a tenant isolation boundary.
 
 ### Via CLI
 
 ```bash
-# Full restore
-artifact-keeper backup restore \
-  --backup-file /backups/full-backup-2026-02-01.tar.gz \
-  --confirm
+# List backups
+ak admin backup list
 
-# Database only
-artifact-keeper backup restore \
-  --backup-file /backups/db-backup-2026-02-01.sql.gz \
-  --database-only \
-  --confirm
+# Create a backup
+ak admin backup create --type full
 
-# Artifacts only
-artifact-keeper backup restore \
-  --backup-file /backups/artifacts-backup-2026-02-01.tar.gz \
-  --artifacts-only \
-  --confirm
+# Restore from a backup
+ak admin backup restore --id <backup-id> --database --artifacts
 ```
 
-### Restore Process
+## Storage
 
-1. **Pre-restore validation**: Verify backup integrity and compatibility
-2. **Service shutdown**: Stop all backend services
-3. **Database restore**: Import PostgreSQL dump
-4. **Artifact restore**: Extract artifact files to storage backend
-5. **Configuration restore**: Apply system configuration
-6. **Post-restore verification**: Verify data integrity
-7. **Service restart**: Start backend services
+Backup archives are written through the configured storage backend under a
+`backups/YYYY/MM/DD/` key prefix.
 
-### Restore Warnings
-
-- Existing data will be overwritten
-- Restore requires downtime
-- Ensure backup version matches current version (or use migration tools)
-- Test restores on staging environment first
-
-## Point-in-Time Recovery (PITR)
-
-Enable PostgreSQL continuous archiving for point-in-time recovery:
-
-### Configuration
+Two environment variables affect backup storage:
 
 ```bash
-# Enable WAL archiving
-POSTGRES_WAL_ARCHIVING=true
-POSTGRES_WAL_ARCHIVE_PATH=/var/lib/postgres/wal_archive
+# Optional: write backups to a dedicated bucket instead of the artifact bucket
+BACKUP_S3_BUCKET=artifact-keeper-backups
 
-# Archive retention
-POSTGRES_WAL_RETENTION_DAYS=7
+# Optional: prepend a key prefix to backup archive paths
+BACKUP_S3_PREFIX=cold-storage
 ```
 
-### PostgreSQL Configuration
+`BACKUP_S3_BUCKET` lets backups live in a separate bucket from artifact
+storage, so a bucket policy or lifecycle rule can differ between the two.
+`BACKUP_S3_PREFIX` is normalised, and an empty or `/` value behaves the same as
+unset. The `backups/` root is always retained, so changing or removing the
+prefix later does not strand existing archives.
 
-In `postgresql.conf`:
+There are no other backup-specific environment variables. Backup destination,
+compression, and retention are not independently configurable; the archive is
+always gzipped tar written through the active storage backend.
 
-```ini
-wal_level = replica
-archive_mode = on
-archive_command = 'cp %p /var/lib/postgres/wal_archive/%f'
-archive_timeout = 300
+## Archive structure
+
+```text
+<uuid>.tar.gz
+├── manifest.json
+├── database/
+│   ├── users.json
+│   ├── repositories.json
+│   ├── artifacts.json
+│   ├── download_statistics.json
+│   ├── api_tokens.json
+│   ├── roles.json
+│   ├── user_roles.json
+│   └── permission_grants.json
+└── artifacts/
+    └── <storage_key>          # one entry per artifact
 ```
 
-### Restore to Point in Time
+Each `database/*.json` file is a JSON array of row objects.
 
-```bash
-artifact-keeper backup restore \
-  --backup-file /backups/base-backup.tar.gz \
-  --recovery-target-time "2026-02-01 11:30:00" \
-  --confirm
-```
-
-## Backup Verification
-
-### Integrity Check
-
-Verify backup integrity without restoring:
-
-```bash
-curl https://registry.example.com/api/v1/admin/backups/backup-123/verify \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
-
-Or via CLI:
-
-```bash
-artifact-keeper backup verify \
-  --backup-file /backups/full-backup-2026-02-01.tar.gz
-```
-
-Checks:
-- Archive can be extracted
-- Checksums match
-- Database dump is valid SQL
-- All referenced artifacts are present
-
-### Test Restore
-
-Perform test restore to temporary location:
-
-```bash
-artifact-keeper backup test-restore \
-  --backup-file /backups/full-backup-2026-02-01.tar.gz \
-  --temp-dir /tmp/restore-test
-```
-
-## Incremental Backups
-
-Reduce backup size and time with incremental backups:
-
-### Configuration
-
-```bash
-BACKUP_TYPE=incremental
-BACKUP_FULL_SCHEDULE="0 2 * * 0"  # Full backup weekly on Sunday
-BACKUP_INCREMENTAL_SCHEDULE="0 2 * * 1-6"  # Incremental daily Mon-Sat
-```
-
-### How It Works
-
-1. **Full backup**: Complete copy of database and artifacts
-2. **Incremental backup**: Only changes since last backup (full or incremental)
-3. **Restore**: Requires full backup + all incremental backups since then
-
-### Restore from Incremental
-
-```bash
-artifact-keeper backup restore \
-  --full-backup /backups/full-2026-01-25.tar.gz \
-  --incremental /backups/incr-2026-01-26.tar.gz \
-  --incremental /backups/incr-2026-01-27.tar.gz \
-  --incremental /backups/incr-2026-02-01.tar.gz \
-  --confirm
-```
-
-## Backup Encryption
-
-Protect backups with encryption:
-
-### Configuration
-
-```bash
-BACKUP_ENCRYPTION=true
-BACKUP_ENCRYPTION_KEY=/etc/artifact-keeper/backup.key
-```
-
-### Generate Encryption Key
-
-```bash
-# Generate 256-bit AES key
-openssl rand -base64 32 > /etc/artifact-keeper/backup.key
-chmod 600 /etc/artifact-keeper/backup.key
-```
-
-### Encrypted Backup
-
-Backups are encrypted using AES-256-GCM:
-
-```bash
-artifact-keeper backup create \
-  --output /backups/encrypted-backup.tar.gz.enc \
-  --encryption-key /etc/artifact-keeper/backup.key
-```
-
-### Restore Encrypted Backup
-
-```bash
-artifact-keeper backup restore \
-  --backup-file /backups/encrypted-backup.tar.gz.enc \
-  --decryption-key /etc/artifact-keeper/backup.key \
-  --confirm
-```
-
-## Managing Backups
-
-### List Backups
-
-```bash
-curl https://registry.example.com/api/v1/admin/backups \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
-
-Response:
+### Manifest
 
 ```json
 {
-  "backups": [
-    {
-      "id": "backup-123",
-      "created_at": "2026-02-01T12:00:00Z",
-      "description": "Scheduled daily backup",
-      "size_mb": 125923,
-      "type": "full",
-      "status": "completed",
-      "location": "s3://artifact-keeper-backups/backups/backup-123.tar.gz"
-    }
-  ]
+  "version": "1.0",
+  "backup_id": "0f8b...",
+  "backup_type": "Full",
+  "created_at": "2026-02-01T12:00:00Z",
+  "database_tables": ["users", "repositories", "..."],
+  "artifact_count": 15234,
+  "total_size_bytes": 0,
+  "checksum": ""
 }
 ```
 
-### Delete Backup
+:::caution[The manifest carries no integrity value]
+`total_size_bytes` and `checksum` are currently always `0` and `""`. The
+manifest is written before the archive is assembled and is not updated
+afterwards, and the restore path does not read the manifest at all. Archive
+integrity rests on the gzip CRC and whatever your storage backend provides.
+Tracked in
+[#3011](https://github.com/artifact-keeper/artifact-keeper/issues/3011).
+:::
+
+## Restoring
+
+### Via API
 
 ```bash
-curl -X DELETE https://registry.example.com/api/v1/admin/backups/backup-123 \
+curl -X POST https://registry.example.com/api/v1/admin/backups/$BACKUP_ID/restore \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"restore_database": true, "restore_artifacts": true}'
+```
+
+Both flags default to `true` when omitted. The response reports which tables
+were touched, how many artifact blobs were written, and any table-level errors:
+
+```json
+{
+  "tables_restored": ["users", "repositories", "artifacts"],
+  "artifacts_restored": 15234,
+  "errors": []
+}
+```
+
+`target_repository_id` is accepted by the request schema but is not currently
+read by the restore implementation. Repository-scoped restore is not available.
+
+### Restore semantics
+
+This is the part that most often differs from expectations.
+
+**Database rows are inserted, never updated or deleted.** Each row is applied
+as `INSERT ... ON CONFLICT DO NOTHING`. The practical consequences:
+
+- Rows that already exist are left exactly as they are. The backup's version
+  does **not** replace the live version.
+- Restore cannot roll a modified row back to its backed-up state.
+- Restore cannot remove rows created since the backup.
+- Repositories and artifacts present on the instance but absent from the backup
+  are preserved, not deleted.
+
+So a restore fills in what is missing. It does not return the instance to its
+state at backup time. If you need true point-in-time recovery, use a
+PostgreSQL-level backup.
+
+**Artifact blobs are overwritten.** Blobs are written to the storage backend at
+their original keys with no existence check and no digest comparison, so a
+restore does replace artifact content at matching keys. Blobs at keys not
+present in the backup are untouched.
+
+**Restore is not transactional.** No transaction wraps the operation, so an
+interrupted restore leaves partial state. Re-running is safe, since inserts are
+conflict-tolerant and blob writes are idempotent.
+
+**Row-level failures are not reported.** Individual row failures, for example a
+foreign key violation, are logged server-side and skipped. They do not appear
+in the `errors` array, which only collects table-level failures. A restore can
+report success while having skipped many rows. Check the server logs.
+
+**No verification happens before ingestion.** The archive is not checksummed or
+signature-verified, and the manifest is not parsed. Only restore archives you
+produced yourself and whose storage location you control.
+
+### Managing backups
+
+```bash
+# List, paginated
+curl "https://registry.example.com/api/v1/admin/backups?page=1&per_page=20" \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Inspect one
+curl https://registry.example.com/api/v1/admin/backups/$BACKUP_ID \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Cancel a running backup
+curl -X POST https://registry.example.com/api/v1/admin/backups/$BACKUP_ID/cancel \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Delete a backup record
+curl -X DELETE https://registry.example.com/api/v1/admin/backups/$BACKUP_ID \
   -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
-### Download Backup
+Only one backup may run at a time per instance.
 
-```bash
-curl https://registry.example.com/api/v1/admin/backups/backup-123/download \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -o backup-123.tar.gz
-```
+## Current limitations
 
-## Disaster Recovery
+Capabilities that are commonly expected here and are not implemented:
 
-### Recovery Plan
+| Not available | Tracking |
+|---|---|
+| Scheduled or automatic backups | No issue yet |
+| Retention or rotation policies | No issue yet |
+| Incremental backups | [#2788](https://github.com/artifact-keeper/artifact-keeper/issues/2788) |
+| Backup archive encryption | No issue yet |
+| Integrity verification endpoint | [#3011](https://github.com/artifact-keeper/artifact-keeper/issues/3011) |
+| Point-in-time recovery | Use PostgreSQL-level backups |
+| Archive download endpoint | No issue yet |
+| Audit events for backup and restore | [#3011](https://github.com/artifact-keeper/artifact-keeper/issues/3011) |
 
-1. **Prepare new environment**: Install Artifact Keeper with same version
-2. **Restore configuration**: Copy environment variables and config files
-3. **Restore database**: Import PostgreSQL dump
-4. **Restore artifacts**: Extract to storage backend
-5. **Verify integrity**: Run health checks
-6. **Update DNS**: Point domain to new instance
-7. **Test**: Verify uploads and downloads work
+Use an external scheduler (cron, a Kubernetes `CronJob`, or your orchestrator's
+equivalent) against the CLI or API for recurring backups, and handle retention
+and encryption at the storage layer.
 
-### Automated DR Setup
+Repository-scoped filesystem storage has a known gap where artifact blobs are
+not captured, tracked in
+[#2863](https://github.com/artifact-keeper/artifact-keeper/issues/2863).
 
-Use infrastructure-as-code to automate disaster recovery:
+## Recommended practice
 
-```bash
-# Terraform/Ansible scripts for provisioning
-terraform apply -var-file=dr.tfvars
+Given the scope above, a workable strategy is:
 
-# Restore from backup
-artifact-keeper backup restore \
-  --backup-file s3://backups/latest.tar.gz \
-  --confirm
+1. **PostgreSQL-level backups** for the database, using `pg_dump` or your
+   platform's snapshot feature. This is your real recovery mechanism, and it
+   covers the tables this feature omits.
+2. **Storage-backend replication or versioning** for artifact blobs. S3
+   versioning and cross-region replication are more robust than moving blobs
+   through an application archive.
+3. **Artifact Keeper backups** for metadata and artifact content portability,
+   for example seeding a new instance or moving a repository set.
+4. **Test your restores.** Restore into a staging instance and confirm the
+   result, particularly because the additive semantics mean a restore over a
+   populated instance behaves differently than a restore into an empty one.
 
-# Verify health
-artifact-keeper health check
-```
-
-## Monitoring
-
-### Backup Metrics
-
-```text
-artifact_keeper_backup_last_success_timestamp
-artifact_keeper_backup_duration_seconds
-artifact_keeper_backup_size_bytes
-artifact_keeper_backup_failures_total
-```
-
-### Alerts
-
-Configure alerts for backup failures:
-
-```yaml
-groups:
-  - name: backup
-    rules:
-      - alert: BackupFailed
-        expr: time() - artifact_keeper_backup_last_success_timestamp > 86400
-        annotations:
-          summary: "Backup has not succeeded in 24 hours"
-
-      - alert: BackupTooLarge
-        expr: artifact_keeper_backup_size_bytes > 1e12
-        annotations:
-          summary: "Backup size exceeds 1TB"
-```
-
-## Best Practices
-
-### Regular Testing
-
-- Test restores monthly
-- Verify backup integrity weekly
-- Document restore procedures
-- Train team on recovery process
-
-### 3-2-1 Rule
-
-- **3** copies of data (production + 2 backups)
-- **2** different media types (disk + cloud)
-- **1** offsite copy (different geographic location)
-
-### Automation
-
-- Automate scheduled backups
-- Automate retention policies
-- Automate backup verification
-- Alert on failures
-
-### Security
-
-- Encrypt backups at rest
-- Encrypt backups in transit
-- Restrict access to backup files
-- Rotate encryption keys periodically
+For moving content between disconnected instances specifically, backup and
+restore is not the right tool: restore carries `users`, `roles`, `user_roles`,
+and `permission_grants`, so restoring an archive from another network injects
+that network's identities and permission grants. Purpose-built export and
+import is tracked in
+[#2463](https://github.com/artifact-keeper/artifact-keeper/issues/2463).
 
 ## Troubleshooting
 
-### Backup Failures
+### Backup fails or produces an unexpectedly small archive
 
-Check logs:
+Check the server logs. Artifact blobs that cannot be fetched from the storage
+backend are skipped silently and do not fail the backup, so a storage
+misconfiguration produces a backup with metadata but few or no blobs. Compare
+`artifact_count` in the manifest against the artifact count you expect.
 
-```bash
-tail -f /var/log/artifact-keeper/backup.log
-```
+### Restore reports success but data is missing
 
-Common issues:
-- Insufficient disk space
-- Database connection errors
-- Storage backend unavailable
-- Permission issues
+Expected in two cases. First, rows that already exist are skipped by design.
+Second, row-level failures are logged rather than returned. Search the server
+logs for `Failed to restore row` to see what was rejected.
 
-### Restore Failures
+### Backup runs out of memory
 
-Verify backup integrity:
+The archive is assembled in memory before being written. On registries with
+large total artifact size, scope the backup with `repository_ids` or
+`exclude_repositories`, or rely on storage-backend replication for blob
+durability instead.
 
-```bash
-artifact-keeper backup verify --backup-file backup.tar.gz
-```
+### Restore appears to do nothing
 
-Check version compatibility:
-
-```bash
-artifact-keeper backup info --backup-file backup.tar.gz
-```
-
-### Performance Issues
-
-- Use compression to reduce backup size
-- Run backups during off-peak hours
-- Use incremental backups for large registries
-- Store backups on fast storage
+Confirm the backup status is `completed`. Restore refuses any backup that is
+not, and this is the only precondition it checks.


### PR DESCRIPTION
## Summary

Rewrites `docs/advanced/backup.mdx` to describe only implemented behaviour. Verified against `artifact-keeper` at `e1f96c1`.

The page documented a substantial set of capabilities that do not exist: AES-256-GCM archive encryption, scheduled backups, retention and rotation policies, point-in-time recovery, incremental backups, an integrity verification endpoint, an archive download endpoint, and config/plugin backup. Around seventeen `BACKUP_*` environment variables were documented; two are actually read (`BACKUP_S3_BUCKET`, `BACKUP_S3_PREFIX`).

The encryption claim was the reason to prioritise this. A reader in a regulated or accredited environment could record "backups are encrypted at rest" as a satisfied control on the strength of this page, and would then have no reason to compensate for the gap. That is worse than the feature simply being absent.

Two behaviours are now documented that were previously stated backwards or omitted entirely:

- **A backup is not a full instance snapshot.** It covers eight metadata tables exported as JSON, not a PostgreSQL dump. No audit log, scan results, findings, SBOMs, signing keys, webhooks, plugins, or system settings.
- **Database restore is additive, not destructive.** Rows are applied as `INSERT ... ON CONFLICT DO NOTHING`, so existing rows are preserved rather than replaced and a restore cannot roll state back to backup time. The page previously said "Existing data will be overwritten", which is the opposite of what happens.

Also now documented: artifact blobs *are* overwritten at matching keys, restore is not transactional, row-level failures are logged server-side rather than returned in the `errors` array, and no checksum or manifest verification happens before ingestion.

Adds a limitations table linking tracking issues, a recommended-practice section pointing at PostgreSQL-level backups for genuine disaster recovery, and a note that backup/restore is the wrong tool for moving content between disconnected instances because restore carries identities and permission grants.

Page goes from 537 to 321 lines.

Backend follow-ups are tracked in artifact-keeper/artifact-keeper#3011 (missing audit events, always-empty manifest checksum, `BackupType` ignored, `record_backup` metrics never emitted) and artifact-keeper/artifact-keeper#3012.

Closes #93

## Test Checklist
- [x] `npm run build` passes
- [x] Verified page renders correctly locally (`npm run dev`)
- [x] Links are valid (no broken links)
- [x] Images load correctly (no images on this page)
- [x] No regressions on other pages
