### PR TITLE
docs(backup): describe only implemented backup functionality

### DIFF
--- a/src/content/docs/docs/advanced/backup.mdx
+++ b/src/content/docs/docs/advanced/backup.mdx
@@ -1,30 +1,61 @@
 ---
 title: "Backup & Recovery"
-description: "Built-in backup system for database and artifacts with scheduled backups and restore capabilities"
+description: "On-demand and scheduled backups of registry metadata and artifacts via the admin API and CLI, with restore and retention cleanup"
 ---
 
-Artifact Keeper includes a comprehensive backup and recovery system to protect your registry data and artifacts.
+Artifact Keeper includes a built-in backup system for registry metadata and artifact files. Backups are created through the admin API or the `ak` CLI and stored as `tar.gz` archives in the configured storage backend.
 
-## Backup Components
+:::caution[Not yet supported]
+The following capabilities are not implemented. Do not rely on them in a recovery or compliance plan:
 
-A complete backup includes:
+- **Encryption of backup archives.** Backup archives are written as plain `tar.gz` files. They contain user records, API token hashes, and artifact content. If your environment requires encrypted backups, you must encrypt at the storage layer, for example S3 server-side encryption (SSE-S3 or SSE-KMS), an encrypted filesystem, or encrypting the archive yourself after download.
+- **Incremental backups.** The API accepts `"type": "incremental"`, but the type is recorded as a label only and does not change what the backup contains. Use the `since` filter to capture changes after a point in time. Native incremental support is tracked in [artifact-keeper#2788](https://github.com/artifact-keeper/artifact-keeper/issues/2788).
+- **Point-in-time recovery.** There is no WAL-based PITR integration. Restores recover the state captured in a completed backup archive.
+- **Backup verification.** There is no verify endpoint or command. The `checksum` and `total_size_bytes` fields in `manifest.json` are currently not populated, so they cannot be used for integrity checking. To validate a backup, download the archive and test-extract it, or perform a test restore against a staging instance.
+:::
 
-1. **Database backup**: PostgreSQL dump of all metadata, users, permissions, and configuration
-2. **Artifact storage**: All artifact files from the storage backend
-3. **System configuration**: Environment settings and plugin configurations
+## What a Backup Contains
+
+A backup is a single `tar.gz` archive with this layout:
+
+```text
+backup.tar.gz
+├── database/
+│   ├── users.json
+│   ├── repositories.json
+│   ├── artifacts.json
+│   ├── download_statistics.json
+│   ├── api_tokens.json
+│   ├── roles.json
+│   ├── user_roles.json
+│   └── permission_grants.json
+├── artifacts/
+│   └── <storage-key>       # raw artifact files, keyed by storage path
+└── manifest.json           # backup id, type, created_at, table list, artifact count
+```
+
+Details worth knowing:
+
+- The database portion is a JSON export of the eight tables listed above, not a `pg_dump`. Other tables, such as system settings, audit logs, webhooks, and scan results, are not included.
+- Artifact files are read from the primary storage backend and embedded in the archive.
+- `manifest.json` records the backup id, type, creation time, exported tables, and artifact count.
+
+If you need a complete disaster-recovery copy of the database, run `pg_dump` against PostgreSQL directly, alongside Artifact Keeper backups.
 
 ## Creating Backups
 
-### Manual Backup via API
+Creating a backup is a two-step process: create a backup record, then execute it. Both require an admin token.
+
+### Via API
 
 ```bash
+# Step 1: create a pending backup record
 curl -X POST https://registry.example.com/api/v1/admin/backups \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "description": "Pre-upgrade backup",
-    "include_artifacts": true,
-    "compression": "gzip"
+    "type": "full",
+    "name": "pre-upgrade"
   }'
 ```
 
@@ -32,506 +63,182 @@ Response:
 
 ```json
 {
-  "backup_id": "backup-123",
-  "status": "in_progress",
-  "started_at": "2026-02-01T12:00:00Z",
-  "description": "Pre-upgrade backup"
+  "id": "0d9a1b2c-3e4f-5a6b-7c8d-9e0f1a2b3c4d",
+  "type": "full",
+  "status": "pending",
+  "storage_path": "backups/2026/02/01/pre-upgrade.tar.gz",
+  "size_bytes": 0,
+  "artifact_count": 0,
+  "created_at": "2026-02-01T12:00:00Z"
 }
 ```
 
-### Manual Backup via CLI
-
 ```bash
-# Full backup
-artifact-keeper backup create \
-  --output /backups/full-backup-2026-02-01.tar.gz \
-  --compression gzip
-
-# Database only
-artifact-keeper backup create \
-  --database-only \
-  --output /backups/db-backup-2026-02-01.sql.gz
-
-# Artifacts only
-artifact-keeper backup create \
-  --artifacts-only \
-  --output /backups/artifacts-backup-2026-02-01.tar.gz
+# Step 2: execute the backup
+curl -X POST https://registry.example.com/api/v1/admin/backups/$BACKUP_ID/execute \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
 ```
 
-## Scheduled Backups
+Only one backup can run at a time. If another backup is in progress, execute returns `409 Conflict`.
 
-### Configuration
+Request fields for `POST /api/v1/admin/backups`:
 
-Enable automatic scheduled backups:
+| Field | Description |
+|-------|-------------|
+| `type` | `full`, `incremental`, or `metadata`. Recorded on the backup and shown in listings, but does not change what is collected. Defaults to `full`. |
+| `repository_ids` | Optional allow-list of repository ids to include. When omitted, every repository is backed up. |
+| `exclude_repositories` | Optional list of repository ids to exclude. Applies to the include list when both are supplied. |
+| `since` | Optional RFC 3339 timestamp. Only artifacts with `updated_at` at or after this time are included, for delta-style backups. |
+| `name` | Optional archive name. Letters, digits, `.`, `_`, and `-`, at most 128 characters. Defaults to the backup UUID. |
 
-```bash
-# Enable scheduled backups
-BACKUP_ENABLED=true
-
-# Backup schedule (cron format)
-BACKUP_SCHEDULE="0 2 * * *"  # Daily at 2 AM
-
-# Backup retention
-BACKUP_RETENTION_DAYS=30
-
-# Backup destination
-BACKUP_PATH=/var/backups/artifact-keeper
-
-# Include artifacts in scheduled backups
-BACKUP_INCLUDE_ARTIFACTS=true
-
-# Compression method
-BACKUP_COMPRESSION=gzip  # or 'zstd', 'none'
-```
-
-### Backup Retention Policy
+### Via CLI
 
 ```bash
-# Keep daily backups for 7 days
-BACKUP_RETENTION_DAILY=7
+# Create a backup record (prints the backup id)
+ak admin backup create --type full
 
-# Keep weekly backups for 4 weeks
-BACKUP_RETENTION_WEEKLY=4
+# Execute it
+ak admin backup execute <backup-id>
 
-# Keep monthly backups for 12 months
-BACKUP_RETENTION_MONTHLY=12
+# Check status and details
+ak admin backup get <backup-id>
 ```
 
-Artifact Keeper automatically manages backup rotation based on these policies.
+See [Admin Commands](/docs/cli/admin-commands) for the full `ak admin` reference.
 
-## Backup Storage
-
-### Local Filesystem
-
-Default storage location:
+## Managing Backups
 
 ```bash
-BACKUP_PATH=/var/backups/artifact-keeper
+# List backups (supports --page and --per-page)
+ak admin backup list
+
+# Cancel a pending or in-progress backup
+ak admin backup cancel <backup-id>
+
+# Delete a backup record and its archive
+ak admin backup delete <backup-id>
 ```
 
-Ensure sufficient disk space:
+The equivalent API endpoints:
 
-```bash
-df -h /var/backups
-```
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/v1/admin/backups` | List backups. Filters: `status`, `type`, `page`, `per_page`. |
+| `GET /api/v1/admin/backups/{id}` | Get one backup. |
+| `POST /api/v1/admin/backups` | Create a pending backup record. |
+| `POST /api/v1/admin/backups/{id}/execute` | Run a pending backup. |
+| `POST /api/v1/admin/backups/{id}/restore` | Restore from a completed backup. |
+| `POST /api/v1/admin/backups/{id}/cancel` | Cancel a pending or in-progress backup. Returns `409` for backups in a terminal state. |
+| `DELETE /api/v1/admin/backups/{id}` | Delete the backup record and its archive. |
 
-### Remote Storage (S3)
+## Where Archives Are Stored
 
-Store backups in S3-compatible storage:
-
-```bash
-BACKUP_STORAGE=s3
-BACKUP_S3_BUCKET=artifact-keeper-backups
-BACKUP_S3_REGION=us-east-1
-BACKUP_S3_PREFIX=backups/
-BACKUP_S3_ACCESS_KEY_ID=your-access-key
-BACKUP_S3_SECRET_ACCESS_KEY=your-secret-key
-```
-
-### Network Storage
-
-Use NFS or other network-attached storage:
-
-```bash
-# Mount NFS share
-sudo mount -t nfs backup-server:/backups /mnt/backups
-
-# Configure backup path
-BACKUP_PATH=/mnt/backups/artifact-keeper
-```
-
-## Backup Structure
-
-### Backup Archive Contents
+Backup archives are written to the storage backend under a date-based key:
 
 ```text
-backup-2026-02-01-120000/
-├── metadata.json          # Backup metadata
-├── database/
-│   └── dump.sql.gz       # PostgreSQL dump
-├── artifacts/
-│   └── storage.tar.gz    # Artifact files
-├── config/
-│   ├── environment.env   # Environment variables
-│   └── plugins/          # Plugin configurations
-└── checksum.sha256       # Integrity verification
+backups/YYYY/MM/DD/<name-or-uuid>.tar.gz
 ```
 
-### Metadata File
+Two environment variables adjust archive placement. They are the only `BACKUP_*` variables the backend reads:
 
-```json
-{
-  "backup_id": "backup-123",
-  "created_at": "2026-02-01T12:00:00Z",
-  "version": "1.0.0",
-  "components": {
-    "database": true,
-    "artifacts": true,
-    "config": true
-  },
-  "statistics": {
-    "database_size_mb": 245,
-    "artifacts_count": 15234,
-    "artifacts_size_mb": 125678,
-    "total_size_mb": 125923
-  },
-  "compression": "gzip",
-  "encryption": false
-}
-```
+| Variable | Description |
+|----------|-------------|
+| `BACKUP_S3_BUCKET` | S3 backend only. Write backup archives to this dedicated bucket instead of the primary artifact bucket. Ignored on filesystem, Azure, and GCS backends. |
+| `BACKUP_S3_PREFIX` | Optional key prefix prepended to the `backups/...` path, mirroring how `S3_PREFIX` prefixes artifact keys. |
+
+Restores, downloads, and deletes always resolve through the `storage_path` recorded when the backup was created, so changing these variables later does not strand existing archives.
+
+There is no separate backup credential configuration. Archive storage uses the same credentials and backend configuration as primary storage.
 
 ## Restoring from Backup
+
+Restore requires a backup in `completed` status.
 
 ### Via API
 
 ```bash
-curl -X POST https://registry.example.com/api/v1/admin/backups/backup-123/restore \
+curl -X POST https://registry.example.com/api/v1/admin/backups/$BACKUP_ID/restore \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "restore_database": true,
-    "restore_artifacts": true,
-    "restore_config": true
+    "restore_artifacts": true
   }'
+```
+
+Both flags default to `true` when omitted. The response reports what happened:
+
+```json
+{
+  "tables_restored": ["users", "roles", "repositories", "artifacts"],
+  "artifacts_restored": 1523,
+  "errors": []
+}
 ```
 
 ### Via CLI
 
 ```bash
-# Full restore
-artifact-keeper backup restore \
-  --backup-file /backups/full-backup-2026-02-01.tar.gz \
-  --confirm
-
-# Database only
-artifact-keeper backup restore \
-  --backup-file /backups/db-backup-2026-02-01.sql.gz \
-  --database-only \
-  --confirm
-
-# Artifacts only
-artifact-keeper backup restore \
-  --backup-file /backups/artifacts-backup-2026-02-01.tar.gz \
-  --artifacts-only \
-  --confirm
+ak admin backup restore <backup-id>
 ```
 
-### Restore Process
+The CLI asks for confirmation before restoring.
 
-1. **Pre-restore validation**: Verify backup integrity and compatibility
-2. **Service shutdown**: Stop all backend services
-3. **Database restore**: Import PostgreSQL dump
-4. **Artifact restore**: Extract artifact files to storage backend
-5. **Configuration restore**: Apply system configuration
-6. **Post-restore verification**: Verify data integrity
-7. **Service restart**: Start backend services
+### Restore Behavior
 
-### Restore Warnings
+- **Database restore is additive.** Rows are inserted with `ON CONFLICT DO NOTHING`. Existing rows are never overwritten, and nothing is deleted first. Restoring into a live instance fills in missing rows; it does not roll back changed ones. For a clean recovery, restore into an empty database.
+- **Artifact restore writes files back to primary storage.** Files in the archive are written to their original storage keys, overwriting any file already at the same key.
+- Tables are restored in dependency order (`users`, `roles`, `user_roles`, `repositories`, `permission_grants`, `artifacts`, `download_statistics`, `api_tokens`).
+- Per-row and per-file failures are collected into the `errors` array rather than aborting the restore. Check it after every restore.
+- The restore runs against the live service. There is no automatic service shutdown, post-restore verification, or restart orchestration; plan maintenance windows yourself.
 
-- Existing data will be overwritten
-- Restore requires downtime
-- Ensure backup version matches current version (or use migration tools)
-- Test restores on staging environment first
+## Scheduled Backups
 
-## Point-in-Time Recovery (PITR)
+The backend includes a scheduler that executes enabled rows in the `backup_schedules` database table on their cron expressions, with multi-replica claim handling so only one replica runs a given occurrence. However, there is currently no API, CLI command, or environment variable for creating or managing schedules.
 
-Enable PostgreSQL continuous archiving for point-in-time recovery:
-
-### Configuration
+The practical way to schedule backups today is external automation calling the CLI or API:
 
 ```bash
-# Enable WAL archiving
-POSTGRES_WAL_ARCHIVING=true
-POSTGRES_WAL_ARCHIVE_PATH=/var/lib/postgres/wal_archive
-
-# Archive retention
-POSTGRES_WAL_RETENTION_DAYS=7
+# crontab: daily backup at 02:00
+0 2 * * * ak admin backup create --type full --quiet | xargs ak admin backup execute
 ```
 
-### PostgreSQL Configuration
+Variables such as `BACKUP_ENABLED`, `BACKUP_SCHEDULE`, and `BACKUP_RETENTION_DAYS` are not read by the backend.
 
-In `postgresql.conf`:
+## Retention Cleanup
 
-```ini
-wal_level = replica
-archive_mode = on
-archive_command = 'cp %p /var/lib/postgres/wal_archive/%f'
-archive_timeout = 300
-```
-
-### Restore to Point in Time
+Old backups are removed by the admin cleanup task, not automatically:
 
 ```bash
-artifact-keeper backup restore \
-  --backup-file /backups/base-backup.tar.gz \
-  --recovery-target-time "2026-02-01 11:30:00" \
-  --confirm
+ak admin cleanup --old-backups
 ```
 
-## Backup Verification
-
-### Integrity Check
-
-Verify backup integrity without restoring:
+Or via API:
 
 ```bash
-curl https://registry.example.com/api/v1/admin/backups/backup-123/verify \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
-
-Or via CLI:
-
-```bash
-artifact-keeper backup verify \
-  --backup-file /backups/full-backup-2026-02-01.tar.gz
-```
-
-Checks:
-- Archive can be extracted
-- Checksums match
-- Database dump is valid SQL
-- All referenced artifacts are present
-
-### Test Restore
-
-Perform test restore to temporary location:
-
-```bash
-artifact-keeper backup test-restore \
-  --backup-file /backups/full-backup-2026-02-01.tar.gz \
-  --temp-dir /tmp/restore-test
-```
-
-## Incremental Backups
-
-Reduce backup size and time with incremental backups:
-
-### Configuration
-
-```bash
-BACKUP_TYPE=incremental
-BACKUP_FULL_SCHEDULE="0 2 * * 0"  # Full backup weekly on Sunday
-BACKUP_INCREMENTAL_SCHEDULE="0 2 * * 1-6"  # Incremental daily Mon-Sat
-```
-
-### How It Works
-
-1. **Full backup**: Complete copy of database and artifacts
-2. **Incremental backup**: Only changes since last backup (full or incremental)
-3. **Restore**: Requires full backup + all incremental backups since then
-
-### Restore from Incremental
-
-```bash
-artifact-keeper backup restore \
-  --full-backup /backups/full-2026-01-25.tar.gz \
-  --incremental /backups/incr-2026-01-26.tar.gz \
-  --incremental /backups/incr-2026-01-27.tar.gz \
-  --incremental /backups/incr-2026-02-01.tar.gz \
-  --confirm
-```
-
-## Backup Encryption
-
-Protect backups with encryption:
-
-### Configuration
-
-```bash
-BACKUP_ENCRYPTION=true
-BACKUP_ENCRYPTION_KEY=/etc/artifact-keeper/backup.key
-```
-
-### Generate Encryption Key
-
-```bash
-# Generate 256-bit AES key
-openssl rand -base64 32 > /etc/artifact-keeper/backup.key
-chmod 600 /etc/artifact-keeper/backup.key
-```
-
-### Encrypted Backup
-
-Backups are encrypted using AES-256-GCM:
-
-```bash
-artifact-keeper backup create \
-  --output /backups/encrypted-backup.tar.gz.enc \
-  --encryption-key /etc/artifact-keeper/backup.key
-```
-
-### Restore Encrypted Backup
-
-```bash
-artifact-keeper backup restore \
-  --backup-file /backups/encrypted-backup.tar.gz.enc \
-  --decryption-key /etc/artifact-keeper/backup.key \
-  --confirm
-```
-
-## Managing Backups
-
-### List Backups
-
-```bash
-curl https://registry.example.com/api/v1/admin/backups \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
-
-Response:
-
-```json
-{
-  "backups": [
-    {
-      "id": "backup-123",
-      "created_at": "2026-02-01T12:00:00Z",
-      "description": "Scheduled daily backup",
-      "size_mb": 125923,
-      "type": "full",
-      "status": "completed",
-      "location": "s3://artifact-keeper-backups/backups/backup-123.tar.gz"
-    }
-  ]
-}
-```
-
-### Delete Backup
-
-```bash
-curl -X DELETE https://registry.example.com/api/v1/admin/backups/backup-123 \
-  -H "Authorization: Bearer $ADMIN_TOKEN"
-```
-
-### Download Backup
-
-```bash
-curl https://registry.example.com/api/v1/admin/backups/backup-123/download \
+curl -X POST https://registry.example.com/api/v1/admin/cleanup \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
-  -o backup-123.tar.gz
+  -H "Content-Type: application/json" \
+  -d '{"cleanup_old_backups": true}'
 ```
 
-## Disaster Recovery
-
-### Recovery Plan
-
-1. **Prepare new environment**: Install Artifact Keeper with same version
-2. **Restore configuration**: Copy environment variables and config files
-3. **Restore database**: Import PostgreSQL dump
-4. **Restore artifacts**: Extract to storage backend
-5. **Verify integrity**: Run health checks
-6. **Update DNS**: Point domain to new instance
-7. **Test**: Verify uploads and downloads work
-
-### Automated DR Setup
-
-Use infrastructure-as-code to automate disaster recovery:
-
-```bash
-# Terraform/Ansible scripts for provisioning
-terraform apply -var-file=dr.tfvars
-
-# Restore from backup
-artifact-keeper backup restore \
-  --backup-file s3://backups/latest.tar.gz \
-  --confirm
-
-# Verify health
-artifact-keeper health check
-```
+Cleanup keeps the most recent `backup_retention_count` completed backups (system setting, default 10) and deletes completed backups older than `retention_days` (default 365). Both settings are managed through `GET`/`POST /api/v1/admin/settings`. Deleting a backup removes both the database record and the archive from storage.
 
 ## Monitoring
 
-### Backup Metrics
+Scheduled backup runs emit Prometheus metrics:
 
 ```text
-artifact_keeper_backup_last_success_timestamp
-artifact_keeper_backup_duration_seconds
-artifact_keeper_backup_size_bytes
-artifact_keeper_backup_failures_total
+ak_backup_operations_total{type, status}
+ak_backup_duration_seconds{type}
 ```
 
-### Alerts
-
-Configure alerts for backup failures:
-
-```yaml
-groups:
-  - name: backup
-    rules:
-      - alert: BackupFailed
-        expr: time() - artifact_keeper_backup_last_success_timestamp > 86400
-        annotations:
-          summary: "Backup has not succeeded in 24 hours"
-
-      - alert: BackupTooLarge
-        expr: artifact_keeper_backup_size_bytes > 1e12
-        annotations:
-          summary: "Backup size exceeds 1TB"
-```
+Backups executed manually through the API or CLI are tracked by their status (`pending`, `in_progress`, `completed`, `failed`, `cancelled`) and error message in `GET /api/v1/admin/backups`.
 
 ## Best Practices
 
-### Regular Testing
-
-- Test restores monthly
-- Verify backup integrity weekly
-- Document restore procedures
-- Train team on recovery process
-
-### 3-2-1 Rule
-
-- **3** copies of data (production + 2 backups)
-- **2** different media types (disk + cloud)
-- **1** offsite copy (different geographic location)
-
-### Automation
-
-- Automate scheduled backups
-- Automate retention policies
-- Automate backup verification
-- Alert on failures
-
-### Security
-
-- Encrypt backups at rest
-- Encrypt backups in transit
-- Restrict access to backup files
-- Rotate encryption keys periodically
-
-## Troubleshooting
-
-### Backup Failures
-
-Check logs:
-
-```bash
-tail -f /var/log/artifact-keeper/backup.log
-```
-
-Common issues:
-- Insufficient disk space
-- Database connection errors
-- Storage backend unavailable
-- Permission issues
-
-### Restore Failures
-
-Verify backup integrity:
-
-```bash
-artifact-keeper backup verify --backup-file backup.tar.gz
-```
-
-Check version compatibility:
-
-```bash
-artifact-keeper backup info --backup-file backup.tar.gz
-```
-
-### Performance Issues
-
-- Use compression to reduce backup size
-- Run backups during off-peak hours
-- Use incremental backups for large registries
-- Store backups on fast storage
+- **Encrypt at the storage layer.** Archives are not encrypted by Artifact Keeper. Use S3 SSE, encrypted volumes, or client-side encryption for any environment with data-at-rest requirements.
+- **Test restores** against a staging instance regularly. A test restore is currently the only reliable way to verify a backup is usable.
+- **Copy archives offsite.** Archives live in the same storage backend as your artifacts by default. Replicate them to a second location, or use `BACKUP_S3_BUCKET` to separate them on S3.
+- **Back up PostgreSQL independently** with `pg_dump` or WAL archiving if you need full database coverage or point-in-time recovery. The built-in backup exports a fixed subset of tables.
+- **Restore into a clean environment** when recovering from data corruption, since database restore never overwrites existing rows.


### PR DESCRIPTION
## Summary
Rewrites `src/content/docs/docs/advanced/backup.mdx` so it documents only backup functionality that actually exists in the backend. Fixes artifact-keeper/artifact-keeper#3012.

The previous page described AES-256-GCM archive encryption, incremental backups, point-in-time recovery, a `GET /backups/{id}/verify` endpoint, backup rotation/schedule/retention environment variables (~15 unread `BACKUP_*` vars), backup Prometheus alert examples, and an `artifact-keeper backup create --output ...` CLI, none of which are implemented. The encryption claim was the most serious: an operator in a regulated environment could record a false at-rest-encryption control assertion sourced from our docs.

The rewritten page documents:
- The real admin API surface: `POST /api/v1/admin/backups` (create), `/execute`, `/restore`, `/cancel`, `DELETE`, and list/get, including the `repository_ids` / `exclude_repositories` / `since` / `name` request fields
- The real CLI surface: `ak admin backup {list,create,get,execute,restore,cancel,delete}` and `ak admin cleanup --old-backups`
- The two environment variables the backend actually reads: `BACKUP_S3_BUCKET` and `BACKUP_S3_PREFIX`
- The actual archive layout (JSON exports of eight tables + artifact files + manifest) and the additive `ON CONFLICT DO NOTHING` restore semantics
- Retention cleanup via `POST /api/v1/admin/cleanup` and the `backup_retention_count` / `retention_days` settings
- A prominent caution listing what is NOT supported (encryption, incremental, PITR, verification) with a warning that archives are not encrypted at rest and operators must encrypt at the storage layer

## Test Checklist
- [x] `npm run build` passes
- [x] Verified page renders correctly locally (`npm run dev`)
- [x] Links are valid (no broken links)
- [x] Images load correctly (page has none)
- [x] No regressions on other pages (full build, 88 pages)


Fixes #96 (mirror of artifact-keeper/artifact-keeper#3012, which this also resolves).
